### PR TITLE
Eliminación mapbox de generate-ol-info

### DIFF
--- a/api-idee-js/tasks/generate-ol-info.js
+++ b/api-idee-js/tasks/generate-ol-info.js
@@ -49,9 +49,7 @@ function getPaths() {
     walker.on('file', (root, stats, next) => {
       const sourcePath = path.join(root, stats.name);
       if (/\.js$/.test(sourcePath)) {
-        if (/^(?!.*node_modules\/ol\/node_modules\/ol-mapbox-style).*/.test(sourcePath)) {
-          paths.push(sourcePath);
-        }
+        paths.push(sourcePath);
       }
       next();
     });


### PR DESCRIPTION
Eliminación de ol-mapbox-style del fichero generate-ol-info.