### PR TITLE
Eliminar fichero tern-project

### DIFF
--- a/api-idee-rest/.tern-project
+++ b/api-idee-rest/.tern-project
@@ -1,6 +1,0 @@
-{
-  "libs": [
-    "browser",
-    "ecma5"
-  ]
-}


### PR DESCRIPTION
Se elimina el fichero https://github.com/Desarrollos-IDEE/API-IDEE/blob/develop/api-idee-rest/.tern-project por desuso