### PR TITLE
Comparativa configuraciones - eslintrc

### DIFF
--- a/api-idee-js/.eslintrc
+++ b/api-idee-js/.eslintrc
@@ -2,8 +2,8 @@
   "extends": "airbnb",
   "globals": {
     "IDEE": true,
-    "ol": "true",
-    "cesium": "true",
+    "ol": true,
+    "cesium": true,
     "Handlebars": true,
     "proj4": true,
     "ActiveXObject": true,


### PR DESCRIPTION
Se mantiene configuración ya que depende de la librería https://www.npmjs.com/package/eslint-config-airbnb
  "settings": {
    "react": {
      "version": "18.2.0"
    }
  },

Si se elimina aparece el siguiente log:
![image](https://github.com/user-attachments/assets/e36597df-a337-4e21-b55f-75742dce50fa)


Se añade Cesium y OL como booleano.