### PR TITLE
Marcar get/setOL3Layer como obsoleto y reemplazo de this.ol3Layer por this.olLayer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,4 @@
 - Añadido bgcolorcontainer a los parámetros de mapas para aplicar un color al fondo del html del mapa de OpenLayers.
 - Se añade mensaje de aviso al usar transparent como parámetro en capas.
 - Se elimina la clase ParametersAdapterV3ToV4 de api-idee-rest.
+- Se marca set/getOL3Layer como obsoleto y se reemplazan referencias a this.ol3Layer por this.olLayer

--- a/api-idee-js/src/facade/js/i18n/en.json
+++ b/api-idee-js/src/facade/js/i18n/en.json
@@ -278,6 +278,8 @@
     "chart_method": "The implementation used can not create Chart styles.",
     "heatmap_method": "The implementation used can not create Heatmap styles.",
     "flowline_method": "The implementation used can not create Flowline styles.",
-    "transparent_deprecated": "'transparent' parameter has been deprecated, it is recommended to use 'isBase' instead."
+    "transparent_deprecated": "'transparent' parameter has been deprecated, it is recommended to use 'isBase' instead.",
+    "getOL3Layer_deprecated": "The getOL3Layer method has been deprecated, it is recommended to use the getLayer method.",
+    "setOL3Layer_deprecated": "The setOL3Layer method has been deprecated, it is recommended to use the setLayer method."
   }
 }

--- a/api-idee-js/src/facade/js/i18n/es.json
+++ b/api-idee-js/src/facade/js/i18n/es.json
@@ -279,6 +279,8 @@
     "chart_method": "La implementación usada no puede crear estilos Chart.",
     "heatmap_method": "La implementación usada no puede crear estilos Heatmap.",
     "flowline_method": "La implementación usada no puede crear estilos FlowLine.",
-    "transparent_deprecated": "El parámetro 'transparent' ha quedado obsoleto, se recomienda usar en su lugar 'isBase'."
+    "transparent_deprecated": "El parámetro 'transparent' ha quedado obsoleto, se recomienda usar en su lugar 'isBase'.",
+    "getOL3Layer_deprecated": "El método getOL3Layer ha quedado obsoleto, se recomienda usar en su lugar getLayer.",
+    "setOL3Layer_deprecated": "El método setOL3Layer ha quedado obsoleto, se recomienda usar en su lugar setLayer."
   }
 }

--- a/api-idee-js/src/facade/js/layer/MapLibre.js
+++ b/api-idee-js/src/facade/js/layer/MapLibre.js
@@ -352,7 +352,7 @@ class MapLibre extends LayerBase {
   set maplibrestyle(maplibrestyle) {
     if (!isNullOrEmpty(maplibrestyle)) {
       this.getImpl().maplibrestyle = maplibrestyle;
-      if (this.getImpl().ol3Layer) {
+      if (this.getImpl().getLayer()) {
         this.getImpl().setStyleMap(maplibrestyle);
       }
     }
@@ -365,7 +365,7 @@ class MapLibre extends LayerBase {
   set url(url) {
     if (!isNullOrEmpty(url)) {
       this.getImpl().url = url;
-      if (this.getImpl().ol3Layer) {
+      if (this.getImpl().getLayer()) {
         this.getImpl().setStyleMap(url);
       }
     }

--- a/api-idee-js/src/impl/ol/js/layer/Draw.js
+++ b/api-idee-js/src/impl/ol/js/layer/Draw.js
@@ -65,7 +65,7 @@ class Draw extends Layer {
     this.map = map;
     this.fire(EventType.ADDED_TO_MAP);
 
-    this.ol3Layer = new OLLayerVector({
+    this.olLayer = new OLLayerVector({
       source: new OLSourceVector({}),
       style: new OLStyle({
         fill: new OLStyleFill({
@@ -93,7 +93,7 @@ class Draw extends Layer {
       this.setVisible(this.inRange());
     }
     const olMap = this.map.getMapImpl();
-    olMap.addLayer(this.ol3Layer);
+    olMap.addLayer(this.olLayer);
   }
 
   /**
@@ -178,7 +178,7 @@ class Draw extends Layer {
       features = features.concat(formattedFeatures);
     });
 
-    this.ol3Layer.getSource().addFeatures(features);
+    this.olLayer.getSource().addFeatures(features);
   }
 
   /**
@@ -196,7 +196,7 @@ class Draw extends Layer {
       if (!isArray(features)) {
         features = [features];
       }
-      this.ol3Layer.getSource().addFeatures(features);
+      this.olLayer.getSource().addFeatures(features);
     }
   }
 
@@ -215,7 +215,7 @@ class Draw extends Layer {
       if (!isArray(features)) {
         features = [features];
       }
-      const olSource = this.ol3Layer.getSource();
+      const olSource = this.olLayer.getSource();
 
       features.forEach((feature) => {
         // try { // Eslint no-useless-catch fix
@@ -236,7 +236,7 @@ class Draw extends Layer {
    */
   getPoints(coordinate) {
     let features = [];
-    const drawSource = this.ol3Layer.getSource();
+    const drawSource = this.olLayer.getSource();
 
     if (!isNullOrEmpty(coordinate)) {
       features = drawSource.getFeaturesAtCoordinate(coordinate);
@@ -258,9 +258,9 @@ class Draw extends Layer {
   destroy() {
     const olMap = this.map.getMapImpl();
 
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.options = null;
     this.map = null;

--- a/api-idee-js/src/impl/ol/js/layer/GenericRaster.js
+++ b/api-idee-js/src/impl/ol/js/layer/GenericRaster.js
@@ -94,7 +94,7 @@ class GenericRaster extends LayerBase {
      */
     this.format = this.options.format;
 
-    this.ol3Layer = vendorOptions;
+    this.olLayer = vendorOptions;
     this.maxExtent = options.userMaxExtent || [];
     this.ids = options.ids;
     this.version = options.version;
@@ -113,32 +113,32 @@ class GenericRaster extends LayerBase {
     this.map = map;
 
     if (!isNullOrEmpty(this.visibility)) {
-      this.ol3Layer.setVisible(this.visibility);
+      this.olLayer.setVisible(this.visibility);
     }
 
     if (!isNullOrEmpty(this.maxZoom)) {
-      this.ol3Layer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
     }
 
     if (!isNullOrEmpty(this.minZoom)) {
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMinZoom(this.minZoom);
     }
 
     if (!isNullOrEmpty(this.zIndex_)) {
-      this.ol3Layer.setZIndex(this.zIndex_);
+      this.olLayer.setZIndex(this.zIndex_);
     }
 
     if (!isNullOrEmpty(this.visibility)) {
-      this.ol3Layer.setVisible(this.visibility);
+      this.olLayer.setVisible(this.visibility);
     }
 
     if (!isNullOrEmpty(this.sldBody)) {
       try {
-        this.ol3Layer.getSource().updateParams({ SLD_BODY: this.sldBody });
+        this.olLayer.getSource().updateParams({ SLD_BODY: this.sldBody });
       } catch (error) {
         const err = getValue('exception').sldBODYError
           .replace('[replace1]', this.name)
-          .replace('[replace2]', this.ol3Layer.constructor.name);
+          .replace('[replace2]', this.olLayer.constructor.name);
 
         // eslint-disable-next-line no-console
         console.warn(err);
@@ -147,11 +147,11 @@ class GenericRaster extends LayerBase {
 
     if (!isNullOrEmpty(this.styles)) {
       try {
-        this.ol3Layer.getSource().updateParams({ STYLES: this.styles });
+        this.olLayer.getSource().updateParams({ STYLES: this.styles });
       } catch (error) {
         const err = getValue('exception').styleError
           .replace('[replace1]', this.name)
-          .replace('[replace2]', this.ol3Layer.constructor.name);
+          .replace('[replace2]', this.olLayer.constructor.name);
 
         // eslint-disable-next-line no-console
         console.warn(err);
@@ -160,50 +160,50 @@ class GenericRaster extends LayerBase {
 
     if (!isNullOrEmpty(this.format)) {
       try {
-        this.ol3Layer.getSource().updateParams({ FORMAT: this.format });
+        this.olLayer.getSource().updateParams({ FORMAT: this.format });
       } catch (error) {
         const err = getValue('exception').formatError
           .replace('[replace1]', this.name)
-          .replace('[replace2]', this.ol3Layer.constructor.name);
+          .replace('[replace2]', this.olLayer.constructor.name);
 
         // eslint-disable-next-line no-console
         console.warn(err);
       }
     }
 
-    this.capabilities = this.getCapabilities(this.ol3Layer, map.getProjection());
+    this.capabilities = this.getCapabilities(this.olLayer, map.getProjection());
 
     if (!isNullOrEmpty(this.maxExtent)) {
-      this.ol3Layer.setExtent(this.maxExtent);
+      this.olLayer.setExtent(this.maxExtent);
     } else if (
-      this.ol3Layer.getSource() instanceof TileWMS
-        || this.ol3Layer.getSource() instanceof ImageWMS) {
-      if (this.ol3Layer.getExtent()) {
-        this.maxExtent = this.ol3Layer.getExtent();
-        this.ol3Layer.setExtent(this.maxExtent);
+      this.olLayer.getSource() instanceof TileWMS
+        || this.olLayer.getSource() instanceof ImageWMS) {
+      if (this.olLayer.getExtent()) {
+        this.maxExtent = this.olLayer.getExtent();
+        this.olLayer.setExtent(this.maxExtent);
       } else {
         this.capabilities.then((capabilities) => {
           this.maxExtent = capabilities.getLayerExtent();
-          this.ol3Layer.setExtent(this.maxExtent);
+          this.olLayer.setExtent(this.maxExtent);
           // eslint-disable-next-line no-underscore-dangle
           this.facadeLayer_.maxExtent_ = this.maxExtent;
         });
       }
-    } else if ((this.ol3Layer.getSource() instanceof OLSourceWMTS)) {
-      const capabilities = this.getCapabilitiesWMTS_(this.ol3Layer);
+    } else if ((this.olLayer.getSource() instanceof OLSourceWMTS)) {
+      const capabilities = this.getCapabilitiesWMTS_(this.olLayer);
       capabilities.then((c) => {
         this.maxExtent = this.getMaxExtentCapabilitiesWMTS_(c);
-        this.ol3Layer.setExtent(this.maxExtent);
+        this.olLayer.setExtent(this.maxExtent);
         // eslint-disable-next-line no-underscore-dangle
         this.facadeLayer_.maxExtent_ = this.maxExtent;
       });
     }
 
-    if (!isUndefined(this.ol3Layer.getSource().getLegendUrl)) {
-      this.legendUrl_ = this.ol3Layer.getSource().getLegendUrl();
+    if (!isUndefined(this.olLayer.getSource().getLegendUrl)) {
+      this.legendUrl_ = this.olLayer.getSource().getLegendUrl();
     }
-    this.ol3Layer.setOpacity(this.opacity_);
-    this.ol3Layer.setVisible(this.visibility);
+    this.olLayer.setOpacity(this.opacity_);
+    this.olLayer.setVisible(this.visibility);
 
     // calculates the resolutions from scales
     if (!isNull(this.options)
@@ -211,15 +211,15 @@ class GenericRaster extends LayerBase {
       const units = this.map.getProjection().units;
       this.options.minResolution = getResolutionFromScale(this.options.minScale, units);
       this.options.maxResolution = getResolutionFromScale(this.options.maxScale, units);
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
-      this.ol3Layer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
     } else if (!isNull(this.options)
       && !isNull(this.options.minResolution) && !isNull(this.options.maxResolution)) {
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
-      this.ol3Layer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
     }
     if (addLayer) {
-      map.getMapImpl().addLayer(this.ol3Layer);
+      map.getMapImpl().addLayer(this.olLayer);
     }
   }
 
@@ -335,9 +335,9 @@ class GenericRaster extends LayerBase {
    * @api
    */
   setURLService(url) {
-    if (!isNullOrEmpty(this.ol3Layer) && !isNullOrEmpty(this.ol3Layer.getSource)
-      && !isNullOrEmpty(this.ol3Layer.getSource()) && !isNullOrEmpty(url)) {
-      this.ol3Layer.getSource().setUrl(url);
+    if (!isNullOrEmpty(this.olLayer) && !isNullOrEmpty(this.olLayer.getSource)
+      && !isNullOrEmpty(this.olLayer.getSource()) && !isNullOrEmpty(url)) {
+      this.olLayer.getSource().setUrl(url);
     }
   }
 
@@ -350,13 +350,13 @@ class GenericRaster extends LayerBase {
    */
   getURLService() {
     let url = '';
-    if (!isNullOrEmpty(this.ol3Layer) && !isNullOrEmpty(this.ol3Layer.getSource)
-      && !isNullOrEmpty(this.ol3Layer.getSource())) {
-      const source = this.ol3Layer.getSource();
+    if (!isNullOrEmpty(this.olLayer) && !isNullOrEmpty(this.olLayer.getSource)
+      && !isNullOrEmpty(this.olLayer.getSource())) {
+      const source = this.olLayer.getSource();
       if (!isNullOrEmpty(source.getUrl)) {
-        url = this.ol3Layer.getSource().getUrl();
+        url = this.olLayer.getSource().getUrl();
       } else if (!isNullOrEmpty(source.getUrls)) {
-        url = this.ol3Layer.getSource().getUrls();
+        url = this.olLayer.getSource().getUrls();
       }
     }
     return url;
@@ -386,7 +386,7 @@ class GenericRaster extends LayerBase {
    * @api stable
    */
   getMaxResolution() {
-    return this.ol3Layer.getMaxResolution();
+    return this.olLayer.getMaxResolution();
   }
 
   /**
@@ -398,7 +398,7 @@ class GenericRaster extends LayerBase {
    * @api stable
    */
   getMinResolution() {
-    return this.ol3Layer.getMinResolution();
+    return this.olLayer.getMinResolution();
   }
 
   /**
@@ -407,7 +407,7 @@ class GenericRaster extends LayerBase {
    * @api stable
    */
   refresh() {
-    this.ol3Layer.getSource().refresh();
+    this.olLayer.getSource().refresh();
   }
 
   /**
@@ -441,16 +441,16 @@ class GenericRaster extends LayerBase {
    * @api stable
    */
   getMaxExtent() {
-    let extent = this.ol3Layer.getExtent();
+    let extent = this.olLayer.getExtent();
     if (isUndefined(extent)) {
-      const tilegrid = this.ol3Layer.getSource().getTileGrid;
+      const tilegrid = this.olLayer.getSource().getTileGrid;
       if (!isUndefined(tilegrid)) {
-        extent = this.ol3Layer.getSource().getTileGrid().getExtent();
-        const extentProj = this.ol3Layer.getSource().getProjection().getCode();
+        extent = this.olLayer.getSource().getTileGrid().getExtent();
+        const extentProj = this.olLayer.getSource().getProjection().getCode();
         extent = ImplUtils
           .transformExtent(extent, extentProj, getProj(this.map.getProjection().code));
       } else {
-        extent = this.ol3Layer.getSource().getImageExtent();
+        extent = this.olLayer.getSource().getImageExtent();
       }
     }
     return extent;
@@ -463,7 +463,7 @@ class GenericRaster extends LayerBase {
    * @api stable
    */
   setMaxExtent(extent) {
-    return this.ol3Layer.setExtent(extent);
+    return this.olLayer.setExtent(extent);
   }
 
   /**
@@ -487,11 +487,11 @@ class GenericRaster extends LayerBase {
   setVersion(newVersion) {
     this.version = newVersion;
     try {
-      this.ol3Layer.getSource().updateParams({ VERSION: newVersion });
+      this.olLayer.getSource().updateParams({ VERSION: newVersion });
     } catch (error) {
       const err = getValue('exception').versionError
         .replace('[replace1]', this.name)
-        .replace('[replace2]', this.ol3Layer.constructor.name);
+        .replace('[replace2]', this.olLayer.constructor.name);
 
       // eslint-disable-next-line no-console
       console.warn(err);
@@ -508,8 +508,8 @@ class GenericRaster extends LayerBase {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
     }
     this.map = null;
   }

--- a/api-idee-js/src/impl/ol/js/layer/GenericVector.js
+++ b/api-idee-js/src/impl/ol/js/layer/GenericVector.js
@@ -77,7 +77,7 @@ class GenericVector extends Vector {
 
     this.fnAddFeatures_ = null;
 
-    this.ol3Layer = vendorOptions;
+    this.olLayer = vendorOptions;
     this.maxExtent = options.userMaxExtent || [];
     this.ids = options.ids;
     this.version = options.version;
@@ -98,51 +98,51 @@ class GenericVector extends Vector {
     this.facadeVector_ = this.facadeLayer_;
 
     if (!this.style) {
-      if (this.ol3Layer.getStyle) {
-        this.styleOl = typeof this.ol3Layer.getStyle() === 'function'
-          ? this.ol3Layer.getStyle()()
-          : this.ol3Layer.getStyle();
+      if (this.olLayer.getStyle) {
+        this.styleOl = typeof this.olLayer.getStyle() === 'function'
+          ? this.olLayer.getStyle()()
+          : this.olLayer.getStyle();
         // eslint-disable-next-line no-underscore-dangle
         this.facadeVector_.style_ = this.styleOl;
-        this.ol3Layer.setStyle(this.styleOl);
+        this.olLayer.setStyle(this.styleOl);
       }
     }
 
     if (!isNullOrEmpty(this.visibility)) {
-      this.ol3Layer.setVisible(this.visibility);
+      this.olLayer.setVisible(this.visibility);
     }
 
     if (!isNullOrEmpty(this.maxZoom)) {
-      this.ol3Layer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
     }
 
     if (!isNullOrEmpty(this.minZoom)) {
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMinZoom(this.minZoom);
     }
 
     if (!isNullOrEmpty(this.zIndex_)) {
-      this.ol3Layer.setZIndex(this.zIndex_);
+      this.olLayer.setZIndex(this.zIndex_);
     }
 
     if (!isNullOrEmpty(this.maxExtent)) {
-      this.ol3Layer.setExtent(this.maxExtent);
+      this.olLayer.setExtent(this.maxExtent);
     }
 
-    if (!isUndefined(this.ol3Layer.getSource().getLegendUrl)) {
-      this.legendUrl_ = this.ol3Layer.getSource().getLegendUrl();
+    if (!isUndefined(this.olLayer.getSource().getLegendUrl)) {
+      this.legendUrl_ = this.olLayer.getSource().getLegendUrl();
     }
-    this.ol3Layer.setOpacity(this.opacity_);
-    this.ol3Layer.setVisible(this.visibility);
+    this.olLayer.setOpacity(this.opacity_);
+    this.olLayer.setVisible(this.visibility);
 
     if (!isNullOrEmpty(this.ids)) {
       const featureId = this.ids.split(',').map((id) => {
         return this.name.concat('.').concat(id);
       });
-      this.ol3Layer.getSource().setUrl(`${this.ol3Layer.getSource().getUrl()}&featureId=${featureId}`);
+      this.olLayer.getSource().setUrl(`${this.olLayer.getSource().getUrl()}&featureId=${featureId}`);
     }
 
     if (!isNullOrEmpty(this.cql)) {
-      this.ol3Layer.getSource().setUrl(`${this.ol3Layer.getSource().getUrl()}&CQL_FILTER=${window.encodeURIComponent(this.cql)}`);
+      this.olLayer.getSource().setUrl(`${this.olLayer.getSource().getUrl()}&CQL_FILTER=${window.encodeURIComponent(this.cql)}`);
     }
 
     // calculates the resolutions from scales
@@ -151,19 +151,19 @@ class GenericVector extends Vector {
       const units = this.map.getProjection().units;
       this.options.minResolution = getResolutionFromScale(this.options.minScale, units);
       this.options.maxResolution = getResolutionFromScale(this.options.maxScale, units);
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
-      this.ol3Layer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
     } else if (!isNull(this.options)
       && !isNull(this.options.minResolution) && !isNull(this.options.maxResolution)) {
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
-      this.ol3Layer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
     }
 
     if (addLayer) {
-      map.getMapImpl().addLayer(this.ol3Layer);
+      map.getMapImpl().addLayer(this.olLayer);
     }
 
-    const source = this.ol3Layer.getSource();
+    const source = this.olLayer.getSource();
 
     // ? Capas con features ya cargados
     if (source.getFeatures().length > 0 && source.getState() === 'ready') {
@@ -184,7 +184,7 @@ class GenericVector extends Vector {
   }
 
   addFeaturesToFacade() {
-    const source = this.ol3Layer.getSource();
+    const source = this.olLayer.getSource();
     if (source.getState() === 'ready' && !this.loaded_) {
       if (source.getFeatures) {
         const features = [];
@@ -234,7 +234,7 @@ class GenericVector extends Vector {
    * @api stable
    */
   deactivate() {
-    this.ol3Layer.getSource().un('change', this.fnAddFeatures_);
+    this.olLayer.getSource().un('change', this.fnAddFeatures_);
     this.fnAddFeatures_ = null;
   }
 
@@ -281,9 +281,9 @@ class GenericVector extends Vector {
    * @api
    */
   setURLService(url) {
-    if (!isNullOrEmpty(this.ol3Layer) && !isNullOrEmpty(this.ol3Layer.getSource)
-      && !isNullOrEmpty(this.ol3Layer.getSource()) && !isNullOrEmpty(url)) {
-      this.ol3Layer.getSource().setUrl(url);
+    if (!isNullOrEmpty(this.olLayer) && !isNullOrEmpty(this.olLayer.getSource)
+      && !isNullOrEmpty(this.olLayer.getSource()) && !isNullOrEmpty(url)) {
+      this.olLayer.getSource().setUrl(url);
     }
   }
 
@@ -296,13 +296,13 @@ class GenericVector extends Vector {
    */
   getURLService() {
     let url = '';
-    if (!isNullOrEmpty(this.ol3Layer) && !isNullOrEmpty(this.ol3Layer.getSource)
-      && !isNullOrEmpty(this.ol3Layer.getSource())) {
-      const source = this.ol3Layer.getSource();
+    if (!isNullOrEmpty(this.olLayer) && !isNullOrEmpty(this.olLayer.getSource)
+      && !isNullOrEmpty(this.olLayer.getSource())) {
+      const source = this.olLayer.getSource();
       if (!isNullOrEmpty(source.getUrl)) {
-        url = this.ol3Layer.getSource().getUrl();
+        url = this.olLayer.getSource().getUrl();
       } else if (!isNullOrEmpty(source.getUrls)) {
-        url = this.ol3Layer.getSource().getUrls();
+        url = this.olLayer.getSource().getUrls();
       }
     }
     return url;
@@ -332,7 +332,7 @@ class GenericVector extends Vector {
    * @api stable
    */
   getMaxResolution() {
-    return this.ol3Layer.getMaxResolution();
+    return this.olLayer.getMaxResolution();
   }
 
   /**
@@ -344,7 +344,7 @@ class GenericVector extends Vector {
    * @api stable
    */
   getMinResolution() {
-    return this.ol3Layer.getMinResolution();
+    return this.olLayer.getMinResolution();
   }
 
   /**
@@ -353,7 +353,7 @@ class GenericVector extends Vector {
    * @api stable
    */
   refresh() {
-    this.ol3Layer.getSource().refresh();
+    this.olLayer.getSource().refresh();
   }
 
   /**
@@ -390,7 +390,7 @@ class GenericVector extends Vector {
     if (this.maxExtent.length !== 0) {
       return this.maxExtent;
     }
-    return this.ol3Layer.getSource().getExtent();
+    return this.olLayer.getSource().getExtent();
   }
 
   /**
@@ -401,7 +401,7 @@ class GenericVector extends Vector {
    */
   setMaxExtent(extent) {
     this.maxExtent = extent;
-    return this.ol3Layer.setExtent(extent);
+    return this.olLayer.setExtent(extent);
   }
 
   /**
@@ -413,11 +413,11 @@ class GenericVector extends Vector {
   setVersion(newVersion) {
     this.version = newVersion;
     try {
-      this.ol3Layer.getSource().updateParams({ VERSION: newVersion });
+      this.olLayer.getSource().updateParams({ VERSION: newVersion });
     } catch (error) {
       const err = getValue('exception').versionError
         .replace('[replace1]', this.name)
-        .replace('[replace2]', this.ol3Layer.constructor.name);
+        .replace('[replace2]', this.olLayer.constructor.name);
 
       // eslint-disable-next-line no-console
       console.warn(err);
@@ -434,8 +434,8 @@ class GenericVector extends Vector {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
     }
     this.map = null;
   }

--- a/api-idee-js/src/impl/ol/js/layer/GeoJSON.js
+++ b/api-idee-js/src/impl/ol/js/layer/GeoJSON.js
@@ -196,8 +196,8 @@ class GeoJSON extends Vector {
   updateSource_() {
     if (isNullOrEmpty(this.vendorOptions_.source)) {
       this.requestFeatures_().then((features) => {
-        if (this.ol3Layer) {
-          this.ol3Layer.setSource(new OLSourceVector({
+        if (this.olLayer) {
+          this.olLayer.setSource(new OLSourceVector({
             loader: (extent, resolution, projection) => {
               this.loaded_ = true;
               // removes previous features
@@ -292,9 +292,9 @@ class GeoJSON extends Vector {
   // destroy () {
   //   let olMap = this.map.getMapImpl();
   //
-  //   if (!isNullOrEmpty(this.ol3Layer)) {
-  //     olMap.removeLayer(this.ol3Layer);
-  //     this.ol3Layer = null;
+  //   if (!isNullOrEmpty(this.olLayer)) {
+  //     olMap.removeLayer(this.olLayer);
+  //     this.olLayer = null;
   //   }
   //   this.options = null;
   //   this.map = null;

--- a/api-idee-js/src/impl/ol/js/layer/GeoTIFF.js
+++ b/api-idee-js/src/impl/ol/js/layer/GeoTIFF.js
@@ -189,8 +189,8 @@ class GeoTIFF extends LayerBase {
         .forEach((layer) => layer.setVisible(false));
 
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the zoom
@@ -199,8 +199,8 @@ class GeoTIFF extends LayerBase {
       if (!isNullOrEmpty(oldZoom)) {
         this.map.setZoom(oldZoom);
       }
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -259,10 +259,10 @@ class GeoTIFF extends LayerBase {
       minResolution: this.options.minResolution,
       maxResolution: this.options.maxResolution,
     }, this.vendorOptions_, true);
-    this.ol3Layer = new TileLayer(properties);
+    this.olLayer = new TileLayer(properties);
 
     if (this.addLayerToMap_) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     this.fire(EventType.ADDED_TO_MAP);
@@ -274,8 +274,8 @@ class GeoTIFF extends LayerBase {
       this.setZIndex(zIndex);
     }
     // activates animation for base layers or animated parameters
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
   }
 
   /**
@@ -410,7 +410,7 @@ class GeoTIFF extends LayerBase {
       // gets the tileGrid
       if (!isNullOrEmpty(resolutions)) {
         const source = this.createOLSource_();
-        this.ol3Layer.setSource(source);
+        this.olLayer.setSource(source);
       }
     }
   }
@@ -478,9 +478,9 @@ class GeoTIFF extends LayerBase {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }

--- a/api-idee-js/src/impl/ol/js/layer/KML.js
+++ b/api-idee-js/src/impl/ol/js/layer/KML.js
@@ -123,8 +123,8 @@ class KML extends Vector {
     this.visibility = visibility;
 
     // layer
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
 
     // screen overlay
@@ -154,7 +154,7 @@ class KML extends Vector {
       extractStyles: this.extractStyles_,
     });
     this.loader_ = new LoaderKML(this.map, this.url, this.formater_);
-    this.ol3Layer = new OLLayerVector(extend({
+    this.olLayer = new OLLayerVector(extend({
       extent: this.maxExtent_,
       opacity: this.opacity_,
     }, this.vendorOptions_, true));
@@ -168,11 +168,11 @@ class KML extends Vector {
       this.setZIndex(this.zIndex_);
     }
     const olMap = this.map.getMapImpl();
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
 
     if (addLayer) {
-      olMap.addLayer(this.ol3Layer);
+      olMap.addLayer(this.olLayer);
     }
   }
 
@@ -243,7 +243,7 @@ class KML extends Vector {
   updateSource_() {
     if (isNullOrEmpty(this.vendorOptions_.source)) {
       this.requestFeatures_().then((response) => {
-        this.ol3Layer.setSource(new OLSourceVector({
+        this.olLayer.setSource(new OLSourceVector({
           loader: () => {
             const screenOverlay = response.screenOverlay;
             // removes previous features
@@ -285,9 +285,9 @@ class KML extends Vector {
   destroy() {
     const olMap = this.map.getMapImpl();
 
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
 
     this.removePopup();

--- a/api-idee-js/src/impl/ol/js/layer/Layer.js
+++ b/api-idee-js/src/impl/ol/js/layer/Layer.js
@@ -4,6 +4,7 @@
 import { isNullOrEmpty, isString } from 'IDEE/util/Utils';
 import MObject from 'IDEE/Object';
 import FacadeLayer from 'IDEE/layer/Layer';
+import { getValue } from '../../../../facade/js/i18n/language';
 /**
  * @classdesc
  * De esta clase heredadan todas las capas base.
@@ -45,9 +46,9 @@ class LayerBase extends MObject {
     this.map = null;
 
     /**
-     * Layer ol3layer. La instancia de la capa ol3.
+     * Layer olLayer. La instancia de la capa ol3.
      */
-    this.ol3Layer = null;
+    this.olLayer = null;
 
     /**
      * Layer options. Opciones personalizadas para esta capa.
@@ -102,8 +103,8 @@ class LayerBase extends MObject {
    */
   isVisible() {
     let visible = false;
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      visible = this.ol3Layer.getVisible();
+    if (!isNullOrEmpty(this.olLayer)) {
+      visible = this.olLayer.getVisible();
     } else {
       visible = this.visibility;
     }
@@ -133,10 +134,10 @@ class LayerBase extends MObject {
    */
   inRange() {
     let inRange = false;
-    if (!isNullOrEmpty(this.ol3Layer)) {
+    if (!isNullOrEmpty(this.olLayer)) {
       const resolution = this.map.getMapImpl().getView().getResolution();
-      const maxResolution = this.ol3Layer.getMaxResolution();
-      const minResolution = this.ol3Layer.getMinResolution();
+      const maxResolution = this.olLayer.getMaxResolution();
+      const minResolution = this.olLayer.getMinResolution();
 
       inRange = ((resolution >= minResolution) && (resolution <= maxResolution));
     }
@@ -154,8 +155,8 @@ class LayerBase extends MObject {
   setVisible(visibility) {
     this.visibility = visibility;
 
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -297,7 +298,9 @@ class LayerBase extends MObject {
    * @deprecated
    */
   getOL3Layer() {
-    return this.ol3Layer;
+    // eslint-disable-next-line no-console
+    console.warn(getValue('exception').getOL3Layer_deprecated);
+    return this.getLayer();
   }
 
   /**
@@ -309,7 +312,7 @@ class LayerBase extends MObject {
    * @expose
    */
   getLayer() {
-    return this.ol3Layer;
+    return this.olLayer;
   }
 
   /**
@@ -322,10 +325,9 @@ class LayerBase extends MObject {
    * @deprecated
    */
   setOL3Layer(layer) {
-    const olMap = this.map.getMapImpl();
-    olMap.removeLayer(this.ol3Layer);
-    this.ol3Layer = layer;
-    olMap.addLayer(layer);
+    // eslint-disable-next-line no-console
+    console.warn(getValue('exception').setOL3Layer_deprecated);
+    this.setLayer(layer);
     return this;
   }
 
@@ -339,8 +341,8 @@ class LayerBase extends MObject {
    */
   setLayer(layer) {
     const olMap = this.map.getMapImpl();
-    olMap.removeLayer(this.ol3Layer);
-    this.ol3Layer = layer;
+    olMap.removeLayer(this.olLayer);
+    this.olLayer = layer;
     olMap.addLayer(layer);
     return this;
   }
@@ -378,7 +380,7 @@ class LayerBase extends MObject {
    * @api
    */
   setMaxExtent(maxExtent) {
-    this.ol3Layer.setExtent(maxExtent);
+    this.olLayer.setExtent(maxExtent);
   }
 
   /**
@@ -390,7 +392,7 @@ class LayerBase extends MObject {
    * @api
    */
   getMaxExtent() {
-    this.ol3Layer.getExtent();
+    this.olLayer.getExtent();
   }
 
   /**

--- a/api-idee-js/src/impl/ol/js/layer/LayerGroup.js
+++ b/api-idee-js/src/impl/ol/js/layer/LayerGroup.js
@@ -61,13 +61,13 @@ class LayerGroup extends Layer {
   addTo(map, addLayer = true) {
     this.map = map;
 
-    this.ol3Layer = new Group(this.getParamsGroup_());
-    this.ol3Layer.setLayers(this.layersCollection);
+    this.olLayer = new Group(this.getParamsGroup_());
+    this.olLayer.setLayers(this.layersCollection);
 
     this.fire(EventType.ADDED_TO_MAP);
 
     if (addLayer) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     this.setOpacity(this.opacity_);
@@ -81,7 +81,7 @@ class LayerGroup extends Layer {
       }
     });
 
-    this.ol3Layer.on('change:zIndex', () => {
+    this.olLayer.on('change:zIndex', () => {
       this.setZIndexChildren();
     });
   }
@@ -94,7 +94,7 @@ class LayerGroup extends Layer {
    * @api stable
    */
   setZIndexChildren() {
-    const olZIndex = this.ol3Layer.getZIndex();
+    const olZIndex = this.olLayer.getZIndex();
     let nexZIndex = olZIndex - 1;
     // Se clona el array de layers para que el reverse no modifique el array original
     const layers = this.layers.concat().reverse();
@@ -211,14 +211,14 @@ class LayerGroup extends Layer {
       });
 
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the bbox
       this.map.getImpl().updateResolutionsFromBaseLayer();
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -276,8 +276,8 @@ class LayerGroup extends Layer {
   removeLayers_(layer) {
     // ? Elimina las capas de this.layers para poder devolverlas
     // ? en el getLayers
-    const id = layer.getImpl().ol3Layer.ol_uid;
-    this.layers = this.layers.filter((l) => l.getImpl().ol3Layer.ol_uid !== id);
+    const id = layer.getImpl().getLayer().ol_uid;
+    this.layers = this.layers.filter((l) => l.getImpl().getLayer().ol_uid !== id);
     this.layersParams_.remove(layer);
   }
 
@@ -296,7 +296,7 @@ class LayerGroup extends Layer {
       return;
     }
 
-    const layerOl = layer.getImpl().ol3Layer;
+    const layerOl = layer.getImpl().getLayer();
     const remove = this.layersCollection.remove(layerOl);
     if (upToMap === false && this.rootGroup !== null) {
       this.setRootGroup_(layer, this.rootGroup);
@@ -345,9 +345,9 @@ class LayerGroup extends Layer {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
 
       // eslint-disable-next-line no-underscore-dangle
       this.map.getImpl().layers_ = this.map.getImpl().layers_.filter((l) => this.name !== l.name);

--- a/api-idee-js/src/impl/ol/js/layer/MBTiles.js
+++ b/api-idee-js/src/impl/ol/js/layer/MBTiles.js
@@ -168,14 +168,14 @@ class MBTiles extends Layer {
       });
 
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the bbox
       this.map.getImpl().updateResolutionsFromBaseLayer();
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -239,7 +239,7 @@ class MBTiles extends Layer {
     const { code } = this.map.getProjection();
     const projection = getProj(code);
     const extent = projection.getExtent();
-    this.ol3Layer = new OLLayerTile(extend({
+    this.olLayer = new OLLayerTile(extend({
       visible: this.visibility,
       opacity: this.opacity_,
       zIndex: this.zIndex_,
@@ -260,10 +260,10 @@ class MBTiles extends Layer {
               sourceExtent: extent,
               projection,
             });
-            this.ol3Layer.setMaxZoom(this.maxZoom);
-            this.ol3Layer.setMinZoom(this.minZoom);
+            this.olLayer.setMaxZoom(this.maxZoom);
+            this.olLayer.setMinZoom(this.minZoom);
             if (addLayer) {
-              this.map.getMapImpl().addLayer(this.ol3Layer);
+              this.map.getMapImpl().addLayer(this.olLayer);
             }
           });
         });
@@ -278,10 +278,10 @@ class MBTiles extends Layer {
         sourceExtent: extent,
         projection,
       });
-      this.ol3Layer.setMaxZoom(this.maxZoom);
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMinZoom(this.minZoom);
       if (addLayer) {
-        this.map.getMapImpl().addLayer(this.ol3Layer);
+        this.map.getMapImpl().addLayer(this.olLayer);
       }
     }
   }
@@ -314,9 +314,9 @@ class MBTiles extends Layer {
         }),
       });
     }
-    this.ol3Layer.setSource(source);
-    this.ol3Layer.setExtent(this.maxExtent_ || opts.sourceExtent);
-    return this.ol3Layer;
+    this.olLayer.setSource(source);
+    this.olLayer.setExtent(this.maxExtent_ || opts.sourceExtent);
+    return this.olLayer;
   }
 
   /**
@@ -410,7 +410,7 @@ class MBTiles extends Layer {
    * @api
    */
   setMaxExtent(maxExtent) {
-    this.ol3Layer.setExtent(maxExtent);
+    this.olLayer.setExtent(maxExtent);
   }
 
   /**
@@ -443,9 +443,9 @@ class MBTiles extends Layer {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }
@@ -478,8 +478,8 @@ class MBTiles extends Layer {
    */
   cloneOLLayer() {
     let olLayer = null;
-    if (this.ol3Layer != null) {
-      const properties = this.ol3Layer.getProperties();
+    if (this.olLayer != null) {
+      const properties = this.olLayer.getProperties();
       olLayer = new OLLayerTile(properties);
     }
     return olLayer;

--- a/api-idee-js/src/impl/ol/js/layer/MBTilesVector.js
+++ b/api-idee-js/src/impl/ol/js/layer/MBTilesVector.js
@@ -170,8 +170,8 @@ class MBTilesVector extends Vector {
    */
   setVisible(visibility) {
     this.visibility = visibility;
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -188,7 +188,7 @@ class MBTilesVector extends Vector {
     const { code } = this.map.getProjection();
     const projection = getProj(code);
     const extent = projection.getExtent();
-    this.ol3Layer = new OLLayerVectorTile(extend({
+    this.olLayer = new OLLayerVectorTile(extend({
       visible: this.visibility,
       opacity: this.opacity_,
       zIndex: this.zIndex_,
@@ -216,8 +216,8 @@ class MBTilesVector extends Vector {
                 format,
               });
 
-              this.ol3Layer.getSource().on('tileloaderror', (evt) => this.checkAllTilesLoaded_(evt));
-              this.ol3Layer.getSource().on('tileloadend', (evt) => this.checkAllTilesLoaded_(evt));
+              this.olLayer.getSource().on('tileloaderror', (evt) => this.checkAllTilesLoaded_(evt));
+              this.olLayer.getSource().on('tileloadend', (evt) => this.checkAllTilesLoaded_(evt));
 
               this.map.on(EventType.CHANGE_ZOOM, () => {
                 if (this.map) {
@@ -228,10 +228,10 @@ class MBTilesVector extends Vector {
                   }
                 }
               });
-              this.ol3Layer.setMaxZoom(this.maxZoom);
-              this.ol3Layer.setMinZoom(this.minZoom);
+              this.olLayer.setMaxZoom(this.maxZoom);
+              this.olLayer.setMinZoom(this.minZoom);
               if (addLayer) {
-                this.map.getMapImpl().addLayer(this.ol3Layer);
+                this.map.getMapImpl().addLayer(this.olLayer);
               }
             });
           });
@@ -247,9 +247,9 @@ class MBTilesVector extends Vector {
         projection,
       });
 
-      this.ol3Layer
+      this.olLayer
         .getSource().on('tileloaderror', (evt) => this.checkAllTilesLoaded_(evt));
-      this.ol3Layer
+      this.olLayer
         .getSource().on('tileloadend', (evt) => this.checkAllTilesLoaded_(evt));
 
       this.map.on(EventType.CHANGE_ZOOM, () => {
@@ -261,10 +261,10 @@ class MBTilesVector extends Vector {
           }
         }
       });
-      this.ol3Layer.setMaxZoom(this.maxZoom);
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMinZoom(this.minZoom);
       if (addLayer) {
-        this.map.getMapImpl().addLayer(this.ol3Layer);
+        this.map.getMapImpl().addLayer(this.olLayer);
       }
     }
   }
@@ -284,7 +284,7 @@ class MBTilesVector extends Vector {
       tileLoadFn = this.loadVectorTile;
     }
     const mvtFormat = new MVT();
-    this.ol3Layer.setSource(new OLSourceVectorTile({
+    this.olLayer.setSource(new OLSourceVectorTile({
       projection: opts.projection,
       url: '{z},{x},{y}',
       tileLoadFunction: (tile) => tileLoadFn(tile, mvtFormat, opts, this),
@@ -295,8 +295,8 @@ class MBTilesVector extends Vector {
       }),
     }));
 
-    this.ol3Layer.setExtent(this.maxExtent_ || opts.sourceExtent);
-    return this.ol3Layer;
+    this.olLayer.setExtent(this.maxExtent_ || opts.sourceExtent);
+    return this.olLayer;
   }
 
   /**
@@ -482,9 +482,9 @@ class MBTilesVector extends Vector {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }
@@ -518,8 +518,8 @@ class MBTilesVector extends Vector {
    */
   getFeatures() {
     let features = [];
-    if (this.ol3Layer) {
-      const olSource = this.ol3Layer.getSource();
+    if (this.olLayer) {
+      const olSource = this.olLayer.getSource();
       const tileCache = olSource.tileCache;
       if (tileCache.getCount() === 0) {
         return features;
@@ -557,7 +557,7 @@ class MBTilesVector extends Vector {
     const { code } = this.map.getProjection();
     const currTileCoord = evt.tile.getTileCoord();
     const olProjection = getProj(code);
-    const tileCache = this.ol3Layer.getSource().getTileCacheForProjection(olProjection);
+    const tileCache = this.olLayer.getSource().getTileCacheForProjection(olProjection);
     const tileImages = tileCache.getValues();
     const loaded = tileImages.some((tile) => {
       const tileCoord = tile.getTileCoord();
@@ -584,8 +584,8 @@ class MBTilesVector extends Vector {
    */
   cloneOLLayer() {
     let olLayer = null;
-    if (this.ol3Layer != null) {
-      const properties = this.ol3Layer.getProperties();
+    if (this.olLayer != null) {
+      const properties = this.olLayer.getProperties();
       olLayer = new OLLayerTile(properties);
     }
     return olLayer;

--- a/api-idee-js/src/impl/ol/js/layer/MVT.js
+++ b/api-idee-js/src/impl/ol/js/layer/MVT.js
@@ -154,18 +154,18 @@ class MVT extends Vector {
     source.on(TileEventType.TILELOADERROR, (evt) => this.checkAllTilesLoaded_(evt));
     // source.on(TileEventType.TILELOADEND, (evt) => this.checkAllTilesLoaded_(evt));
 
-    this.ol3Layer = new OLLayerVectorTile(extend({
+    this.olLayer = new OLLayerVectorTile(extend({
       source,
       extent,
     }, this.vendorOptions_, true));
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
 
     this.setOpacity(this.opacity_);
     this.setVisible(this.visibility_);
 
     if (addLayer) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     // clear features when zoom changes
@@ -289,8 +289,8 @@ class MVT extends Vector {
    */
   getFeatures(skipFilter, filter) {
     let features = [];
-    if (this.ol3Layer) {
-      const olSource = this.ol3Layer.getSource();
+    if (this.olLayer) {
+      const olSource = this.olLayer.getSource();
       const tileCache = olSource.tileCache;
       if (tileCache.getCount() === 0) {
         return features;
@@ -325,8 +325,8 @@ class MVT extends Vector {
    */
   getFeatureById(id) {
     const features = [];
-    if (this.ol3Layer) {
-      const tileCache = this.ol3Layer.getSource().tileCache;
+    if (this.olLayer) {
+      const tileCache = this.olLayer.getSource().tileCache;
       const kk = tileCache.getCount();
       if (kk === 0) {
         return features;
@@ -362,7 +362,7 @@ class MVT extends Vector {
   checkAllTilesLoaded_(evt) {
     const currTileCoord = evt.tile.getTileCoord();
     const olProjection = getProj(this.projection_);
-    const tileCache = this.ol3Layer.getSource().getTileCacheForProjection(olProjection);
+    const tileCache = this.olLayer.getSource().getTileCacheForProjection(olProjection);
     const tileImages = tileCache.getValues();
     const loaded = tileImages.every((tile) => {
       const tileCoord = tile.getTileCoord();

--- a/api-idee-js/src/impl/ol/js/layer/MapLibre.js
+++ b/api-idee-js/src/impl/ol/js/layer/MapLibre.js
@@ -137,14 +137,14 @@ class MapLibre extends LayerBase {
         },
       };
 
-    this.ol3Layer = new MapLibreLayer(params);
+    this.olLayer = new MapLibreLayer(params);
 
     this.setZooms_();
     this.setResolutions_();
     this.setVisible(this.visibility_);
 
     if (addLayer) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     if (this.disableBackgroundColor !== undefined) {
@@ -163,20 +163,20 @@ class MapLibre extends LayerBase {
 
   handlerLoadMapLibre_() {
     return new Promise((resolve) => {
-      if (this.ol3Layer.mapLibreMap !== undefined && this.ol3Layer.mapLibreMap.loaded()) {
+      if (this.olLayer.mapLibreMap !== undefined && this.olLayer.mapLibreMap.loaded()) {
         resolve();
       } else {
         const handlerMapLibreMap = () => {
-          if (this.ol3Layer.mapLibreMap && this.ol3Layer.mapLibreMap.loaded()) {
-            this.ol3Layer.un('change:visible', handlerMapLibreMap);
-            this.ol3Layer.mapLibreMap.off('load', handlerMapLibreMap);
+          if (this.olLayer.mapLibreMap && this.olLayer.mapLibreMap.loaded()) {
+            this.olLayer.un('change:visible', handlerMapLibreMap);
+            this.olLayer.mapLibreMap.off('load', handlerMapLibreMap);
             resolve();
           }
         };
-        if (this.ol3Layer.mapLibreMap === undefined) {
-          this.ol3Layer.on('change:visible', handlerMapLibreMap);
+        if (this.olLayer.mapLibreMap === undefined) {
+          this.olLayer.on('change:visible', handlerMapLibreMap);
         } else {
-          this.ol3Layer.mapLibreMap.on('load', handlerMapLibreMap);
+          this.olLayer.mapLibreMap.on('load', handlerMapLibreMap);
         }
       }
     });
@@ -185,10 +185,10 @@ class MapLibre extends LayerBase {
   handlerStyleLoad_() {
     return new Promise((resolve) => {
       this.handlerLoadMapLibre_().then(() => {
-        if (this.ol3Layer.mapLibreMap.isStyleLoaded()) {
+        if (this.olLayer.mapLibreMap.isStyleLoaded()) {
           resolve();
         } else {
-          this.ol3Layer.mapLibreMap.once('style.load', () => {
+          this.olLayer.mapLibreMap.once('style.load', () => {
             resolve();
           });
         }
@@ -198,7 +198,7 @@ class MapLibre extends LayerBase {
 
   changeDisableBackgroundColor_() {
     this.handlerStyleLoad_().then(() => {
-      const mapLibreMap = this.ol3Layer.mapLibreMap;
+      const mapLibreMap = this.olLayer.mapLibreMap;
 
       const layers = mapLibreMap.getStyle().layers;
       const idBackground = layers.find(({ type }) => type === 'background').id;
@@ -220,11 +220,11 @@ class MapLibre extends LayerBase {
   }
 
   getMapLibreStyleFromId(ids = []) {
-    if (this.ol3Layer) {
+    if (this.olLayer) {
       if (ids.length === 0) {
-        return this.ol3Layer.mapLibreMap.getStyle().layers;
+        return this.olLayer.mapLibreMap.getStyle().layers;
       }
-      return this.ol3Layer.mapLibreMap.getStyle().layers.filter(({ id }) => ids.includes(id));
+      return this.olLayer.mapLibreMap.getStyle().layers.filter(({ id }) => ids.includes(id));
     }
   }
 
@@ -238,8 +238,8 @@ class MapLibre extends LayerBase {
   setStyleMap(style) {
     this.handlerStyleLoad_().then(() => {
       // eslint-disable-next-line no-underscore-dangle
-      this.ol3Layer.mapLibreMap.style._loaded = false;
-      this.ol3Layer.mapLibreMap.setStyle(style);
+      this.olLayer.mapLibreMap.style._loaded = false;
+      this.olLayer.mapLibreMap.setStyle(style);
     });
   }
 
@@ -250,20 +250,20 @@ class MapLibre extends LayerBase {
       this.options.minResolution = getResolutionFromScale(this.options.minScale, units);
       this.options.maxResolution = getResolutionFromScale(this.options.maxScale, units);
 
-      this.ol3Layer.setMinResolution(this.options.minResolution);
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
     }
 
     if (!isNull(this.options)
       && !isNull(this.options.minResolution) && !isNull(this.options.maxResolution)) {
-      this.ol3Layer.setMinResolution(this.options.minResolution);
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
     }
   }
 
   setZooms_() {
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
   }
 
   /**
@@ -277,11 +277,11 @@ class MapLibre extends LayerBase {
    */
   setPaintProperty(layer, property, value) {
     this.handlerStyleLoad_().then(() => {
-      if (this.ol3Layer.mapLibreMap.isStyleLoaded()) {
-        this.ol3Layer.mapLibreMap.setPaintProperty(layer, property, value);
+      if (this.olLayer.mapLibreMap.isStyleLoaded()) {
+        this.olLayer.mapLibreMap.setPaintProperty(layer, property, value);
       } else {
-        this.ol3Layer.mapLibreMap.once('style.load', () => {
-          this.ol3Layer.mapLibreMap.setPaintProperty(layer, property, value);
+        this.olLayer.mapLibreMap.once('style.load', () => {
+          this.olLayer.mapLibreMap.setPaintProperty(layer, property, value);
         });
       }
     });
@@ -298,11 +298,11 @@ class MapLibre extends LayerBase {
    */
   setLayoutProperty(layer, property, value) {
     this.handlerStyleLoad_().then(() => {
-      if (this.ol3Layer.mapLibreMap.isStyleLoaded()) {
-        this.ol3Layer.mapLibreMap.setLayoutProperty(layer, property, value);
+      if (this.olLayer.mapLibreMap.isStyleLoaded()) {
+        this.olLayer.mapLibreMap.setLayoutProperty(layer, property, value);
       } else {
-        this.ol3Layer.mapLibreMap.once('style.load', () => {
-          this.ol3Layer.mapLibreMap.setLayoutProperty(layer, property, value);
+        this.olLayer.mapLibreMap.once('style.load', () => {
+          this.olLayer.mapLibreMap.setLayoutProperty(layer, property, value);
         });
       }
     });
@@ -491,9 +491,9 @@ class MapLibre extends LayerBase {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     if (!isNullOrEmpty(this.layers)) {
       this.layers.map(this.map.removeLayers, this.map);

--- a/api-idee-js/src/impl/ol/js/layer/OGCAPIFeatures.js
+++ b/api-idee-js/src/impl/ol/js/layer/OGCAPIFeatures.js
@@ -172,7 +172,7 @@ class OGCAPIFeatures extends Vector {
       this.loader_ = new LoaderWFS(this.map, this.service_, this.formater_);
 
       // const isCluster = (this.facadeVector_.getStyle() instanceof StyleCluster);
-      const ol3LayerSource = this.ol3Layer.getSource();
+      const ol3LayerSource = this.olLayer.getSource();
       this.requestFeatures_().then((features) => {
         if (forceNewSource === true || isNullOrEmpty(ol3LayerSource)) {
           const newSource = new OLSourceVector({
@@ -190,10 +190,10 @@ class OGCAPIFeatures extends Vector {
           //     distance,
           //     source: newSource,
           //   });
-          //   this.ol3Layer.setStyle(this.facadeVector_.getStyle().getImpl().olStyleFn);
-          //   this.ol3Layer.setSource(clusterSource);
-          // } else if (this.ol3Layer) {
-          this.ol3Layer.setSource(newSource);
+          //   this.olLayer.setStyle(this.facadeVector_.getStyle().getImpl().olStyleFn);
+          //   this.olLayer.setSource(clusterSource);
+          // } else if (this.olLayer) {
+          this.olLayer.setSource(newSource);
           // }
         } else {
           // if (isCluster) {
@@ -347,9 +347,9 @@ class OGCAPIFeatures extends Vector {
   //  */
   // destroy() {
   //   let olMap = this.map.getMapImpl();
-  //   if (!isNullOrEmpty(this.ol3Layer)) {
-  //     olMap.removeLayer(this.ol3Layer);
-  //     this.ol3Layer = null;
+  //   if (!isNullOrEmpty(this.olLayer)) {
+  //     olMap.removeLayer(this.olLayer);
+  //     this.olLayer = null;
   //   }
   //   this.map = null;
   // };

--- a/api-idee-js/src/impl/ol/js/layer/OSM.js
+++ b/api-idee-js/src/impl/ol/js/layer/OSM.js
@@ -112,8 +112,8 @@ class OSM extends Layer {
         });
 
         // set this layer visible
-        if (!isNullOrEmpty(this.ol3Layer)) {
-          this.ol3Layer.setVisible(visibility);
+        if (!isNullOrEmpty(this.olLayer)) {
+          this.olLayer.setVisible(visibility);
         }
 
         // updates resolutions and keep the bbox
@@ -122,8 +122,8 @@ class OSM extends Layer {
         if (!isNullOrEmpty(oldBbox)) {
           this.map.setBbox(oldBbox);
         }
-      } else if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      } else if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
     }
   }
@@ -140,7 +140,7 @@ class OSM extends Layer {
     this.map = map;
     this.fire(EventType.ADDED_TO_MAP);
 
-    this.ol3Layer = new OLLayerTile(extend(
+    this.olLayer = new OLLayerTile(extend(
       { visible: this.visibility },
       this.vendorOptions_,
       true,
@@ -151,7 +151,7 @@ class OSM extends Layer {
     }
 
     if (addLayer) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     this.map.getImpl().getMapImpl().getControls().getArray()
@@ -191,12 +191,12 @@ class OSM extends Layer {
       this.setResolutions(this.resolutions_);
     }
 
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
 
     // activates animation for base layers or animated parameters
     const animated = ((this.isBase === true) || (this.options.animated === true));
-    this.ol3Layer.set('animated', animated);
+    this.olLayer.set('animated', animated);
 
     // set the extent when the map changed
     this.map.on(EventType.CHANGE_PROJ, () => this.updateSource_());
@@ -236,13 +236,13 @@ class OSM extends Layer {
         units,
       );
     }
-    if (!isNullOrEmpty(this.ol3Layer) && isNullOrEmpty(this.vendorOptions_.source)) {
+    if (!isNullOrEmpty(this.olLayer) && isNullOrEmpty(this.vendorOptions_.source)) {
       const extent = this.facadeLayer_.getMaxExtent();
       const newSource = new SourceOSM({
         url: this.url,
       });
-      this.ol3Layer.setSource(newSource);
-      this.ol3Layer.setExtent(extent);
+      this.olLayer.setSource(newSource);
+      this.olLayer.setExtent(extent);
     }
   }
 
@@ -268,7 +268,7 @@ class OSM extends Layer {
    * @api stable
    */
   setMaxExtent(maxExtent) {
-    this.ol3Layer.setExtent(maxExtent);
+    this.olLayer.setExtent(maxExtent);
   }
 
   /**
@@ -305,9 +305,9 @@ class OSM extends Layer {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
 
     this.map.getLayers().forEach((layer) => {
@@ -357,8 +357,8 @@ class OSM extends Layer {
    */
   cloneOLLayer() {
     let olLayer = null;
-    if (this.ol3Layer != null) {
-      const properties = this.ol3Layer.getProperties();
+    if (this.olLayer != null) {
+      const properties = this.olLayer.getProperties();
       olLayer = new OLLayerTile(properties);
     }
     return olLayer;
@@ -374,8 +374,8 @@ class OSM extends Layer {
    */
   cloneLayer() {
     let olLayer = null;
-    if (this.ol3Layer != null) {
-      const properties = this.ol3Layer.getProperties();
+    if (this.olLayer != null) {
+      const properties = this.olLayer.getProperties();
       olLayer = new OLLayerTile(properties);
     }
     return olLayer;

--- a/api-idee-js/src/impl/ol/js/layer/Vector.js
+++ b/api-idee-js/src/impl/ol/js/layer/Vector.js
@@ -103,7 +103,7 @@ class Vector extends Layer {
     this.map = map;
     this.fire(EventType.ADDED_TO_MAP);
     map.on(EventType.CHANGE_PROJ, this.setProjection_.bind(this), this);
-    this.ol3Layer = new OLLayerVector(this.vendorOptions_);
+    this.olLayer = new OLLayerVector(this.vendorOptions_);
     this.updateSource_();
     if (this.opacity_) {
       this.setOpacity(this.opacity_);
@@ -111,12 +111,12 @@ class Vector extends Layer {
     this.setVisible(this.visibility);
     if (addLayer) {
       const olMap = this.map.getMapImpl();
-      olMap.addLayer(this.ol3Layer);
+      olMap.addLayer(this.olLayer);
     }
 
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
-    this.ol3Layer.setExtent(this.maxExtent_);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
+    this.olLayer.setExtent(this.maxExtent_);
   }
 
   /**
@@ -128,8 +128,8 @@ class Vector extends Layer {
    */
   updateSource_() {
     if (isNullOrEmpty(this.vendorOptions_.source)) {
-      if (isNullOrEmpty(this.ol3Layer.getSource())) {
-        this.ol3Layer.setSource(new OLSourceVector());
+      if (isNullOrEmpty(this.olLayer.getSource())) {
+        this.olLayer.setSource(new OLSourceVector());
       }
       this.redraw();
       this.loaded_ = true;
@@ -486,9 +486,9 @@ class Vector extends Layer {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }

--- a/api-idee-js/src/impl/ol/js/layer/WFS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WFS.js
@@ -210,7 +210,7 @@ class WFS extends Vector {
       this.loader_ = new LoaderWFS(this.map, this.service_, this.formater_);
 
       // const isCluster = (this.facadeVector_.getStyle() instanceof StyleCluster);
-      const ol3LayerSource = this.ol3Layer.getSource();
+      const ol3LayerSource = this.olLayer.getSource();
       this.requestFeatures_().then((features) => {
         if (forceNewSource === true || isNullOrEmpty(ol3LayerSource)) {
           const newSource = new OLSourceVector({
@@ -228,10 +228,10 @@ class WFS extends Vector {
           //     distance,
           //     source: newSource,
           //   });
-          //   this.ol3Layer.setStyle(this.facadeVector_.getStyle().getImpl().olStyleFn);
-          //   this.ol3Layer.setSource(clusterSource);
-          // } else if (this.ol3Layer) {
-          this.ol3Layer.setSource(newSource);
+          //   this.olLayer.setStyle(this.facadeVector_.getStyle().getImpl().olStyleFn);
+          //   this.olLayer.setSource(clusterSource);
+          // } else if (this.olLayer) {
+          this.olLayer.setSource(newSource);
           // }
         } else {
           // if (isCluster) {
@@ -355,9 +355,9 @@ class WFS extends Vector {
   //  */
   // destroy() {
   //   let olMap = this.map.getMapImpl();
-  //   if (!isNullOrEmpty(this.ol3Layer)) {
-  //     olMap.removeLayer(this.ol3Layer);
-  //     this.ol3Layer = null;
+  //   if (!isNullOrEmpty(this.olLayer)) {
+  //     olMap.removeLayer(this.olLayer);
+  //     this.olLayer = null;
   //   }
   //   this.map = null;
   // };

--- a/api-idee-js/src/impl/ol/js/layer/WMS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WMS.js
@@ -224,8 +224,8 @@ class WMS extends LayerBase {
         .forEach((layer) => layer.setVisible(false));
 
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the zoom
@@ -234,8 +234,8 @@ class WMS extends LayerBase {
       if (!isNullOrEmpty(oldZoom)) {
         this.map.setZoom(oldZoom);
       }
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -273,9 +273,9 @@ class WMS extends LayerBase {
     }
 
     if (this.tiled === true) {
-      this.ol3Layer = new OLLayerTile(this.paramsOLLayers());
+      this.olLayer = new OLLayerTile(this.paramsOLLayers());
     } else {
-      this.ol3Layer = new OLLayerImage(this.paramsOLLayers());
+      this.olLayer = new OLLayerImage(this.paramsOLLayers());
     }
 
     if (this.useCapabilities || this.isWMSfull) {
@@ -321,12 +321,12 @@ class WMS extends LayerBase {
   setResolutions(resolutions) {
     this.resolutions_ = resolutions;
     this.facadeLayer_.calculateMaxExtent().then((extent) => {
-      if (!isNullOrEmpty(this.ol3Layer)) {
+      if (!isNullOrEmpty(this.olLayer)) {
         const minResolution = this.options.minResolution;
         const maxResolution = this.options.maxResolution;
         const source = this.createOLSource_(resolutions, minResolution, maxResolution, extent);
-        this.ol3Layer.setSource(source);
-        this.ol3Layer.setExtent(extent);
+        this.olLayer.setSource(source);
+        this.olLayer.setExtent(extent);
       }
     });
   }
@@ -381,10 +381,10 @@ class WMS extends LayerBase {
     }
 
     const source = this.createOLSource_(resolutions, minResolution, maxResolution, extent);
-    this.ol3Layer.setSource(source);
+    this.olLayer.setSource(source);
 
     if (this.addLayerToMap_) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
 
     this.setVisible(this.visibility);
@@ -399,9 +399,9 @@ class WMS extends LayerBase {
     }
     // activates animation for base layers or animated parameters
     const animated = ((this.isBase === true) || (this.options.animated === true));
-    this.ol3Layer.set('animated', animated);
-    this.ol3Layer.setMaxZoom(this.maxZoom);
-    this.ol3Layer.setMinZoom(this.minZoom);
+    this.olLayer.set('animated', animated);
+    this.olLayer.setMaxZoom(this.maxZoom);
+    this.olLayer.setMinZoom(this.minZoom);
   }
 
   // Devuelve un capabilities formateado en el caso
@@ -599,12 +599,12 @@ class WMS extends LayerBase {
   updateMinMaxResolution(projection) {
     if (!isNullOrEmpty(this.options.minResolution)) {
       this.options.minResolution = getResolutionFromScale(this.options.minScale, projection.units);
-      this.ol3Layer.setMinResolution(this.options.minResolution);
+      this.olLayer.setMinResolution(this.options.minResolution);
     }
 
     if (!isNullOrEmpty(this.options.maxResolution)) {
       this.options.maxResolution = getResolutionFromScale(this.options.maxScale, projection.units);
-      this.ol3Layer.setMaxResolution(this.options.maxResolution);
+      this.olLayer.setMaxResolution(this.options.maxResolution);
     }
   }
 
@@ -629,7 +629,7 @@ class WMS extends LayerBase {
       // gets the tileGrid
       if (!isNullOrEmpty(resolutions)) {
         const source = this.createOLSource_(resolutions, minResolution, maxResolution, maxExtent);
-        this.ol3Layer.setSource(source);
+        this.olLayer.setSource(source);
       }
     }
     // });
@@ -782,9 +782,9 @@ class WMS extends LayerBase {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     if (!isNullOrEmpty(this.layers)) {
       this.layers.map(this.map.removeLayers, this.map);

--- a/api-idee-js/src/impl/ol/js/layer/WMTS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WMTS.js
@@ -134,7 +134,7 @@ class WMTS extends LayerBase {
       this.options.maxResolution = getResolutionFromScale(this.options.maxScale, units);
     }
 
-    this.ol3Layer = new OLLayerTile(extend({
+    this.olLayer = new OLLayerTile(extend({
       visible: this.visibility,
       minResolution: this.options.minResolution,
       maxResolution: this.options.maxResolution,
@@ -219,7 +219,7 @@ class WMTS extends LayerBase {
           }),
           extent,
         });
-        this.ol3Layer.setSource(newSource);
+        this.olLayer.setSource(newSource);
       });
     }
   }
@@ -241,8 +241,8 @@ class WMTS extends LayerBase {
         .forEach((layer) => layer.setVisible(false));
 
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the zoom
@@ -251,8 +251,8 @@ class WMTS extends LayerBase {
       if (!isNullOrEmpty(oldZoom)) {
         this.map.setZoom(oldZoom);
       }
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -279,17 +279,17 @@ class WMTS extends LayerBase {
         wmtsSource = new OLSourceWMTS(options);
       }
       this.facadeLayer_.setFormat(capabilitiesOptionsVariable.format);
-      this.ol3Layer.setSource(wmtsSource);
+      this.olLayer.setSource(wmtsSource);
 
       // keeps z-index values before ol resets
       const zIndex = this.zIndex_;
 
       if (this.addLayerToMap_) {
-        this.map.getMapImpl().addLayer(this.ol3Layer);
+        this.map.getMapImpl().addLayer(this.olLayer);
       }
 
-      this.ol3Layer.setMaxZoom(this.maxZoom);
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMinZoom(this.minZoom);
 
       // sets its z-index
       if (zIndex !== null) {
@@ -297,7 +297,7 @@ class WMTS extends LayerBase {
       }
 
       // activates animation always for WMTS layers
-      this.ol3Layer.set('animated', true);
+      this.olLayer.set('animated', true);
       this.fire(EventType.ADDED_TO_MAP, this);
     }
   }
@@ -341,14 +341,14 @@ class WMTS extends LayerBase {
         });
       }
       this.facadeLayer_.setFormat(format);
-      this.ol3Layer.setSource(wmtsSource);
+      this.olLayer.setSource(wmtsSource);
 
       // keeps z-index values before ol resets
       const zIndex = this.zIndex_;
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
       setTimeout(() => {
-        this.ol3Layer.setMaxZoom(this.maxZoom);
-        this.ol3Layer.setMinZoom(this.minZoom);
+        this.olLayer.setMaxZoom(this.maxZoom);
+        this.olLayer.setMinZoom(this.minZoom);
       }, 500);
 
       // sets its z-index
@@ -357,7 +357,7 @@ class WMTS extends LayerBase {
       }
 
       // activates animation always for WMTS layers
-      this.ol3Layer.set('animated', true);
+      this.olLayer.set('animated', true);
       this.fire(EventType.ADDED_TO_MAP, this);
     }
   }
@@ -557,9 +557,9 @@ class WMTS extends LayerBase {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }
@@ -642,8 +642,8 @@ class WMTS extends LayerBase {
    */
   getTileColTileRow(coordinate, zoom) {
     let tcr = null;
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      const source = this.ol3Layer.getSource();
+    if (!isNullOrEmpty(this.olLayer)) {
+      const source = this.olLayer.getSource();
       if (!isNullOrEmpty(source)) {
         const { tileGrid } = source;
         tcr = tileGrid.getTileCoordForCoordAndZ(coordinate, zoom);
@@ -665,8 +665,8 @@ class WMTS extends LayerBase {
    */
   getRelativeTileCoordInPixel_(coordinate, zoom) {
     let coordPixel;
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      const source = this.ol3Layer.getSource();
+    if (!isNullOrEmpty(this.olLayer)) {
+      const source = this.olLayer.getSource();
       if (!isNullOrEmpty(source)) {
         const { tileGrid } = source;
         const tileCoord = tileGrid.getTileCoordForCoordAndZ(coordinate, zoom);

--- a/api-idee-js/src/impl/ol/js/layer/XYZ.js
+++ b/api-idee-js/src/impl/ol/js/layer/XYZ.js
@@ -143,8 +143,8 @@ class XYZ extends Layer {
     // if this layer is base then it hides all base layers
     if ((visibility === true) && (this.isBase !== false)) {
       // set this layer visible
-      if (!isNullOrEmpty(this.ol3Layer)) {
-        this.ol3Layer.setVisible(visibility);
+      if (!isNullOrEmpty(this.olLayer)) {
+        this.olLayer.setVisible(visibility);
       }
 
       // updates resolutions and keep the zoom
@@ -153,8 +153,8 @@ class XYZ extends Layer {
       if (!isNullOrEmpty(oldZoom)) {
         this.map.setZoom(oldZoom);
       }
-    } else if (!isNullOrEmpty(this.ol3Layer)) {
-      this.ol3Layer.setVisible(visibility);
+    } else if (!isNullOrEmpty(this.olLayer)) {
+      this.olLayer.setVisible(visibility);
     }
   }
 
@@ -170,7 +170,7 @@ class XYZ extends Layer {
     this.map = map;
     const projection = getProj('EPSG:3857');
     const extent = projection.getExtent();
-    this.ol3Layer = new OLTileLayer(extend({
+    this.olLayer = new OLTileLayer(extend({
       visible: this.visibility,
       opacity: this.opacity_,
       zIndex: this.zIndex_,
@@ -178,7 +178,7 @@ class XYZ extends Layer {
     }, this.vendorOptions_, true));
 
     if (addLayer) {
-      this.map.getMapImpl().addLayer(this.ol3Layer);
+      this.map.getMapImpl().addLayer(this.olLayer);
     }
     let source = this.vendorOptions_.source;
     if (isNullOrEmpty(source)) {
@@ -189,12 +189,12 @@ class XYZ extends Layer {
         crossOrigin: this.crossOrigin,
       });
     }
-    this.ol3Layer.setSource(source);
+    this.olLayer.setSource(source);
     if (this.tileGridMaxZoom !== undefined && this.tileGridMaxZoom > 0) {
-      this.ol3Layer.getSource().tileGrid.maxZoom = this.tileGridMaxZoom;
+      this.olLayer.getSource().tileGrid.maxZoom = this.tileGridMaxZoom;
     } else {
-      this.ol3Layer.setMaxZoom(this.maxZoom);
-      this.ol3Layer.setMinZoom(this.minZoom);
+      this.olLayer.setMaxZoom(this.maxZoom);
+      this.olLayer.setMinZoom(this.minZoom);
     }
   }
 
@@ -207,7 +207,7 @@ class XYZ extends Layer {
    * @api
    */
   setTileUrlFunction(tileUrlFunction) {
-    this.ol3Layer.getSource().setTileUrlFunction(tileUrlFunction);
+    this.olLayer.getSource().setTileUrlFunction(tileUrlFunction);
   }
 
   /**
@@ -219,7 +219,7 @@ class XYZ extends Layer {
    * @api
    */
   getTileUrlFunction() {
-    this.ol3Layer.getSource().getTileUrlFunction();
+    this.olLayer.getSource().getTileUrlFunction();
   }
 
   /**
@@ -244,9 +244,9 @@ class XYZ extends Layer {
    */
   destroy() {
     const olMap = this.map.getMapImpl();
-    if (!isNullOrEmpty(this.ol3Layer)) {
-      olMap.removeLayer(this.ol3Layer);
-      this.ol3Layer = null;
+    if (!isNullOrEmpty(this.olLayer)) {
+      olMap.removeLayer(this.olLayer);
+      this.olLayer = null;
     }
     this.map = null;
   }

--- a/api-idee-js/src/impl/ol/js/style/Generic.js
+++ b/api-idee-js/src/impl/ol/js/style/Generic.js
@@ -218,7 +218,7 @@ class Generic extends Simple {
         // través de la styleFuntion. Por lo que se intenta arreglar de esta manera.
         // this.updateFacadeOptions(options);
         // eslint-disable-next-line no-underscore-dangle
-        // this.layer_.getImpl().ol3Layer.styleFunction_ = this.olStyleFn_;
+        // this.layer_.getImpl().olLayer.styleFunction_ = this.olStyleFn_;
         if (isArray(vendorOptions)) {
           return vendorOptions;
         }

--- a/api-idee-js/src/plugins/layerswitcher/src/templates/addInGroup.html
+++ b/api-idee-js/src/plugins/layerswitcher/src/templates/addInGroup.html
@@ -5,7 +5,7 @@
             {{translations.defaultSelectOption}}</option>
         {{#each groups}}
         <option tabindex="0" class="m-check-layerswitcher-addservices m-layerswitcher-icons-check"
-            value="{{impl_.ol3Layer.ol_uid}}">{{legend}}</option>
+            value="{{impl_.olLayer.ol_uid}}">{{legend}}</option>
         {{/each}}
     </select>
 </div>

--- a/api-idee-js/src/plugins/queryattributes/src/impl/ol/js/queryattributescontrol.js
+++ b/api-idee-js/src/plugins/queryattributes/src/impl/ol/js/queryattributescontrol.js
@@ -1,3 +1,5 @@
+import { getValue } from '../../../facade/js/i18n/language';
+
 /**
  * @module IDEE/impl/control/QueryAttributesControl
  */
@@ -198,7 +200,9 @@ export default class QueryAttributesControl extends IDEE.impl.Control {
    * @deprecated
    */
   getOL3Layer(layer) {
-    return layer.getImpl().getOL3Layer();
+    // eslint-disable-next-line no-console
+    console.warn(getValue('exception').getOL3Layer_deprecated);
+    return this.getLayer(layer);
   }
 
   /**

--- a/api-idee-js/test/development/CP-0002-layers/CP-002.js
+++ b/api-idee-js/test/development/CP-0002-layers/CP-002.js
@@ -155,7 +155,7 @@ if (listAllFunctions && listAllFunctions.length > 0) { // Confirmar que existen 
           } else if (auxName === 'setLayerGroup') {
             showResult(auxButton, 'SET_setLayerGroup', capaPrueba[auxName](['OSM', 'OSM']));
           } else if (auxName === 'setLayoutProperty') { // ONLY USED IN "maplibre_001"
-            // window.maplibre.impl_.ol3Layer.mapLibreMap.setLayoutProperty('cubierta_vegetal_bosque_pol', 'visibility', 'none');
+            // window.maplibre.impl_.olLayer.mapLibreMap.setLayoutProperty('cubierta_vegetal_bosque_pol', 'visibility', 'none');
             showResult(auxButton, 'SET_setLayoutProperty', capaPrueba[auxName]('cubierta_vegetal_bosque_pol', 'visibility', 'none'));
           } else if (auxName === 'setLegend') {
             showResult(auxButton, 'SET_setLegend', capaPrueba[auxName]('PRUEBA_TEXTO_LEYENDA'));
@@ -178,7 +178,7 @@ if (listAllFunctions && listAllFunctions.length > 0) { // Confirmar que existen 
               showResult(auxButton, 'SET_setOpacity_1', capaPrueba[auxName](1));
             }
           } else if (auxName === 'setPaintProperty') { // ONLY USED IN "maplibre_001"
-            // window.maplibre.impl_.ol3Layer.mapLibreMap.setPaintProperty('cubierta_vegetal_bosque_pol','fill-color','rgba( 0, 0, 0, 1.00 )');
+            // window.maplibre.impl_.olLayer.mapLibreMap.setPaintProperty('cubierta_vegetal_bosque_pol','fill-color','rgba( 0, 0, 0, 1.00 )');
             showResult(auxButton, 'SET_setPaintProperty', capaPrueba[auxName]('cubierta_vegetal_bosque_pol', 'fill-color', 'rgba( 0, 0, 0, 1.00 )'));
           } else if (auxName === 'setStyle') { // ONLY USED IN "maplibre_001"
             showResult(auxButton, 'SET_setStyle', capaPrueba[auxName]('https://demotiles.maplibre.org/style.json'));


### PR DESCRIPTION
1. Se marca como obsoleto los métodos  get/setOL3Layer
2. Se elimina referencias a this.ol3Layer por this.olLayer