### PR TITLE
Se elimina filtro para evitar capas teseladas en version 1.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,4 @@
 - Añadido bgcolorcontainer a los parámetros de mapas para aplicar un color al fondo del html del mapa de OpenLayers.
 - Se añade mensaje de aviso al usar transparent como parámetro en capas.
 - Se elimina la clase ParametersAdapterV3ToV4 de api-idee-rest.
+- Se elimina filtro que impide usar el parámetro tiled si la capa WMS tiene la versión 1.3.0.

--- a/api-idee-js/src/impl/ol/js/layer/WMS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WMS.js
@@ -483,11 +483,8 @@ class WMS extends LayerBase {
         TRANSPARENT: !this.isBase,
         FORMAT: this.format,
         STYLES: this.styles,
+        TILED: this.tiled,
       };
-
-      if (this.version !== '1.3.0') {
-        layerParams.TILED = this.tiled;
-      }
 
       if (!isNullOrEmpty(this.sldBody)) {
         layerParams.SLD_BODY = this.sldBody;


### PR DESCRIPTION
Se elimina filtro para evitar capas teseladas en version 1.3.0, ahora se pueden añadir tileadas o no con la versión 1.3.0.