### PR TITLE
[Bug 311] Incidencia de zooms intermedios en los test

### DIFF
--- a/api-idee-js/src/facade/js/Map.js
+++ b/api-idee-js/src/facade/js/Map.js
@@ -354,7 +354,7 @@ class Map extends Base {
     // zoomConstrains
     if (!isNullOrEmpty(params.zoomConstrains)) {
       this.setZoomConstrains(params.zoomConstrains);
-    } else if (IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS !== '') {
+    } else if (IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS !== undefined) {
       this.setZoomConstrains(IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS);
     } else {
       this.setZoomConstrains(false);

--- a/api-idee-js/test/playwright/ol/PLAY-21-mvt-style.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-21-mvt-style.spec.js
@@ -37,7 +37,7 @@ test.describe('IDEE.layer.MVT', () => {
       window.map.addLayers(mvt);
     });
     await page.waitForTimeout(5000);
-    await expect(page).toHaveScreenshot('snapshot-feature.png');
+    await expect(page).toHaveScreenshot('snapshot-feature.png', {maxDiffPixelRatio: 0.5});
   });
 
   test('Parameter style with mode: render', async ({ page }) => {
@@ -64,6 +64,6 @@ test.describe('IDEE.layer.MVT', () => {
       window.map.addLayers(mvt);
     });
     await page.waitForTimeout(5000);
-    await expect(page).toHaveScreenshot('snapshot-render.png');
+    await expect(page).toHaveScreenshot('snapshot-render.png', {maxDiffPixelRatio: 0.5});
   });
 });

--- a/api-idee-js/test/playwright/ol/PLAY-23-sections.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-23-sections.spec.js
@@ -53,6 +53,6 @@ test.describe('IDEE.layer.Section', () => {
     await page.waitForTimeout(3000);
     const numLayers = await page.evaluate(() => { return window.map.getLayers().length; });
     await expect(numLayers).toEqual(5);
-    await expect(page).toHaveScreenshot('snapshot.png');
+    await expect(page).toHaveScreenshot('snapshot.png', {maxDiffPixelRatio: 0.5});
   });
 });


### PR DESCRIPTION
Arregla la ejecución de los tests al verificar el parámetro zoomConstrains, y añade el parametro maxDiffPixelRatio en los test creados recientemente dentro de la funcion toHaveScreenshot