### PR TITLE
Bug 318 correccion click feature pixelratio

### DIFF
--- a/api-idee-js/src/facade/js/Map.js
+++ b/api-idee-js/src/facade/js/Map.js
@@ -354,7 +354,7 @@ class Map extends Base {
     // zoomConstrains
     if (!isNullOrEmpty(params.zoomConstrains)) {
       this.setZoomConstrains(params.zoomConstrains);
-    } else if (IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS !== undefined) {
+    } else if (IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS !== '' && IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS !== undefined) {
       this.setZoomConstrains(IDEE.config.MAP_VIEWER_ZOOM_CONSTRAINS);
     } else {
       this.setZoomConstrains(false);

--- a/api-idee-js/src/impl/ol/js/Map.js
+++ b/api-idee-js/src/impl/ol/js/Map.js
@@ -217,7 +217,7 @@ class Map extends MObject {
      * Calcula la resolción del mapa a partir del dpi
      * definido en el fichero de configuración.
      */
-    const pixelRatio = Number.parseFloat(dpi) / 72;
+    const pixelRatio = Number.parseFloat(dpi) / 72 || 1;
 
     /**
      * Implementación del mapa.


### PR DESCRIPTION
- Corrige error en los test PLAY-09-vector.spec.js y PLAY-13-mostrar-nombre-capa.spec.js, donde al hacer clic en la feature para desplegar el popup, si el mapa tiene un pixel ratio distinto de 1, las coordenadas del clic no corresponden con la ubicación de la feature.