### PR TITLE
Error al visualizar estadísticos

### DIFF
--- a/api-idee-js/src/impl/ol/js/olchart/OLChart.js
+++ b/api-idee-js/src/impl/ol/js/olchart/OLChart.js
@@ -180,6 +180,52 @@ class OLChart extends OLStyleRegularShape {
   }
 
   /**
+   * Devuelve los datos del gráfico.
+   * @public
+   * @function
+   * @returns {Object}
+   * @api stable
+   */
+  /* get data() {
+    return this.data_;
+  } */
+
+  /**
+   * Sobreescritura los datos del gráfico.
+   * @public
+   * @function
+   * @param {Object} data Datos del gráfico.
+   * @api stable
+   */
+  /* set data(data) {
+    this.data_ = data;
+    this.renderChart_();
+  } */
+
+  /**
+   * Devuelve el radio del gráfico.
+   * @public
+   * @function
+   * @returns {number}
+   * @api stable
+   */
+  /* get radius() {
+    return this.radius_;
+  } */
+
+  /**
+   * Sobrescribe el radio del gráfico.
+   * @public
+   * @function
+   * @param {number} radius Radio del gráfico.
+   * @api stable
+   */
+  /* set radius(radius) {
+    this.radius_ = radius;
+    this.renderChart_();
+  } */
+
+  /**
    * Sobrescribe de tipos de relación de donut y radio.
    * @public
    * @function

--- a/api-idee-js/src/impl/ol/js/olchart/OLChart.js
+++ b/api-idee-js/src/impl/ol/js/olchart/OLChart.js
@@ -180,52 +180,6 @@ class OLChart extends OLStyleRegularShape {
   }
 
   /**
-   * Devuelve los datos del gráfico.
-   * @public
-   * @function
-   * @returns {Object}
-   * @api stable
-   */
-  get data() {
-    return this.data_;
-  }
-
-  /**
-   * Sobreescritura los datos del gráfico.
-   * @public
-   * @function
-   * @param {Object} data Datos del gráfico.
-   * @api stable
-   */
-  set data(data) {
-    this.data_ = data;
-    this.renderChart_();
-  }
-
-  /**
-   * Devuelve el radio del gráfico.
-   * @public
-   * @function
-   * @returns {number}
-   * @api stable
-   */
-  get radius() {
-    return this.radius_;
-  }
-
-  /**
-   * Sobrescribe el radio del gráfico.
-   * @public
-   * @function
-   * @param {number} radius Radio del gráfico.
-   * @api stable
-   */
-  set radius(radius) {
-    this.radius_ = radius;
-    this.renderChart_();
-  }
-
-  /**
    * Sobrescribe de tipos de relación de donut y radio.
    * @public
    * @function


### PR DESCRIPTION
Permite la visualización de estadísticos de tipo Chart con la versión actualizada de OpenLayers. El error provenía del cambio de flujo de ejecución entre versiones.
En la versión previa (8.1), la sobre escritura de función no se estaba realizando (por ejemplo set data() o set radius()), pero con la actualización de OpenLayers, el flujo de ejecución ya reconoce estas funciones, modificando su comportamiento y originando este error, ya que estaba intentando generar los estadísticos antes de inicializar las variables de la clase.