### PR TITLE
fix: fija la versión de zip.js (DEBE QUITARSE CUANDO SE CORRIJA EN CESIUM)

### DIFF
--- a/api-idee-js/package.json
+++ b/api-idee-js/package.json
@@ -49,6 +49,7 @@
     "@geoblocks/ol-maplibre-layer": "1.0.3",
     "@handlebars/allow-prototype-access": "1.0.5",
     "@ngageoint/geopackage": "4.2.6",
+    "@zip.js/zip.js": "^2.7.72",
     "cesium": "1.118.0",
     "chroma-js": "1.4.1",
     "draggabilly": "3.0.0",


### PR DESCRIPTION
**¡¡¡ TEMPORAL !!!**
Para poder generar desplegable