### PR TITLE
Error can't access property 0, t.offset is undefined, al utilizar infoCoordinates

### DIFF
--- a/api-idee-js/src/impl/ol/js/point/FontSymbol.js
+++ b/api-idee-js/src/impl/ol/js/point/FontSymbol.js
@@ -29,6 +29,7 @@ class FontSymbol extends OLFontSymbol {
    * @api stable
    */
   constructor(options = {}) {
+    const offset = options.offset || [0, 0];
     // super call
     super({
       glyph: options.glyph,
@@ -39,8 +40,8 @@ class FontSymbol extends OLFontSymbol {
       radius: options.radius,
       form: options.form,
       gradient: options.gradient,
-      offsetX: options.offset[0],
-      offsetY: options.offset[1],
+      offsetX: offset[0],
+      offsetY: offset[1],
       opacity: options.opacity,
       rotation: options.rotation,
       rotateWithView: options.rotateWithView,


### PR DESCRIPTION
fix: Prevenir TypeError cuando options.offset es undefined.

Añadida una constante para que no salga undefined offset.