### PR TITLE
Reproyecta la información obtenida de los loader de GeoJSON y KML del SRC estándar al SRC del mapa

### DIFF
--- a/api-idee-js/src/impl/ol/js/loader/KML.js
+++ b/api-idee-js/src/impl/ol/js/loader/KML.js
@@ -7,6 +7,7 @@ import { isUndefined, isNullOrEmpty } from 'IDEE/util/Utils';
 import FacadeFeature from 'IDEE/feature/Feature';
 import Exception from 'IDEE/exception/exception';
 import { getValue } from 'IDEE/i18n/language';
+import { get as getProj } from 'ol/proj';
 
 /**
  * @classdesc
@@ -181,7 +182,7 @@ class KML extends MObject {
            Fix: While the KML URL was being resolved the map projection
            might have been changed therefore the projection is readed again
          */
-        const lastProjection = this.map_.getProjection().code;
+        const lastProjection = getProj('EPSG:4326');
         if (!isNullOrEmpty(response.text)) {
           const features = this.format_.readCustomFeatures(response.text, {
             featureProjection: lastProjection,
@@ -198,6 +199,13 @@ class KML extends MObject {
               properties: olFeature.getProperties(),
             });
             feature.getImpl().getFeature().setStyle(olFeature.getStyle());
+            feature.getImpl()
+              .getFeature()
+              .getGeometry()
+              .transform(
+                lastProjection,
+                this.map_.getProjection().code,
+              );
             return feature;
           });
 


### PR DESCRIPTION
Se corrige la carga del loader KML, en vez de tomar la proyección del mapa, toma el SRC 4326 (estándar del formato KML) y después se reproyectan los objetos Features al SRC que tiene el mapa en ese momento.
Para el formato GeoJSON esta reproyección ya se realiza. La función **loadInternal_** del archivo JSONP (impl/ol/js/reader) llama a la función **read** del archivo GeoJSON (impl/ol/format) la cual para obtener el SRC de origen llama a la función **readProjectionFromObject** que se encuentra en ese mismo archivo. Esta función tomará el SRC que venga definido en el objeto GeoJSON y, en caso de que no esté definida, tomará por defecto el estándar 4326.
<img width="746" height="527" alt="image" src="https://github.com/user-attachments/assets/e597d440-edbe-42f6-9737-1155ad03e779" />
