### PR TITLE
Soluciona el error de compilación de los test PLAY-30 y PLAY-35

### DIFF
--- a/api-idee-js/test/playwright/ol/PLAY-30-wmcNames.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-30-wmcNames.spec.js
@@ -4,7 +4,7 @@ test.describe('IDEE.layer.WMC', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/test/playwright/ol/basic-ol.html');
     await page.evaluate(() => {
-      IDEE.proxy(true);
+      // IDEE.proxy(true);
       const map = IDEE.map({
         container: 'map',
         projection: 'EPSG:25830*d',

--- a/api-idee-js/test/playwright/ol/PLAY-35-wmc.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-35-wmc.spec.js
@@ -4,7 +4,7 @@ test.describe('IDEE.layer.WMC', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/test/playwright/ol/basic-ol.html');
     await page.evaluate(() => {
-      IDEE.proxy(true);
+      // IDEE.proxy(true);
       const map = IDEE.map({
         container: 'map',
         projection: 'EPSG:3857*m',


### PR DESCRIPTION
Se comenta la línea de código `IDEE.proxy(true);` de ambos test para que la compilación se efectúe correctamente. De esta manera, las peticiones se puede efectuar correctamente en el entorno de Playwright.