### PR TITLE
Arregla petición API REST para obtener la proyección del mapa

### DIFF
--- a/api-idee-rest/src/main/java/es/api_idee/api/ActionsWS.java
+++ b/api-idee-rest/src/main/java/es/api_idee/api/ActionsWS.java
@@ -137,7 +137,6 @@ public class ActionsWS {
 
 		JSONObject projectionJSON = new JSONObject();
 		projectionJSON.put("code", projection[0]);
-		projectionJSON.put("units", projection[1]);
 
 		return JSBuilder.wrapCallback(projectionJSON, callbackFn);
 	}


### PR DESCRIPTION
Modifica el método _showDefaultProjection_ eliminando la variable que almacena la unidad de la proyección, ya que ahora no es necesaria.