### PR TITLE
Ajusta la escala numérica a los niveles definidos por TileMatrixSet de OGC

### DIFF
--- a/api-idee-js/src/configuration.js
+++ b/api-idee-js/src/configuration.js
@@ -328,6 +328,14 @@ params.forEach((param) => {
   IDEE.config('DPI', 72);
 
   /**
+   * MAP Viewer - DPI OGC (Dots per inch for OGC services)
+   * 
+   * @private
+   * @type {Number}
+   */
+  IDEE.config('DPI_OGC', 90.714285714);
+
+  /**
    * Mueve el mapa cuando se hace clic sobre un objeto
    * geográfico, (extract = true) o no (extract = false)
    *

--- a/api-idee-js/src/impl/ol/js/control/Scale.js
+++ b/api-idee-js/src/impl/ol/js/control/Scale.js
@@ -34,7 +34,7 @@ const updateElement = (container, map) => {
   const containerVariable = container;
   const view = map.getMapImpl().getView();
   const resolution = view.getResolution();
-  const dpi = IDEE.config.DPI;
+  const dpi = IDEE.config.DPI_OGC;
   const num = Utils.getScaleForResolution(resolution, view, dpi);
 
   if (!isNullOrEmpty(num)) {
@@ -157,9 +157,8 @@ class Scale extends Control {
             this.scaleContainer_.textContent = scaleText;
             const view = this.facadeMap_.getMapImpl().getView();
             const resolution = Utils.getCurrentScale(
-              this.facadeMap_.getMapImpl().getView(),
               scaleText,
-              IDEE.config.DPI,
+              IDEE.config.DPI_OGC,
             );
             view.animate({
               center: view.getCenter(),

--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -11,7 +11,6 @@ import {
   get as getProj,
   getTransform,
   transformExtent,
-  getPointResolution,
 } from 'ol/proj';
 import OLFeature from 'ol/Feature';
 import WKB from 'ol/format/WKB';
@@ -681,16 +680,8 @@ class Utils {
    * @public
    * @api
    */
-  static getScaleForResolution(resolution, view, dpi = 72) {
-    const projection = view.getProjection();
-    const center = view.getCenter();
-    const inchesPerMeter = 39.3700787;
-    const units = projection.getUnits();
-
-    const pointResolution = getPointResolution(projection, resolution, center, units);
-    const scale = pointResolution * inchesPerMeter * dpi;
-
-    return Math.round(scale);
+  static getScaleForResolution(resolution) {
+    return Math.round(resolution / 0.00028);
   }
 
   /**
@@ -700,19 +691,19 @@ class Utils {
    * @function
    * @param {View} view Vista del mapa.
    * @param {String} inputValue Valor de entrada para la escala.
-   * @param {Number} dpi DPI del mapa (por defecto 72).
+   * @param {Number} dpi DPI del mapa.
    * @returns {Number} Resolución de la vista correspondiente a la escala.
    * @public
    * @api
    */
-  static getCurrentScale(view, inputValue, dpi = 72) {
+  static getCurrentScale(inputValue, dpi) {
     const inchesPerMeter = 39.3700787;
     const scale = parseFloat(inputValue.replace(/\./g, ''));
     const calculateResolution = (targetScale) => {
       let resolution = targetScale / (inchesPerMeter * dpi);
 
       for (let i = 0; i < 3; i + 1) {
-        const currentScale = this.getScaleForResolution(resolution, view, dpi);
+        const currentScale = this.getScaleForResolution(resolution);
         const error = targetScale - currentScale;
         resolution *= (targetScale / currentScale);
 

--- a/api-idee-js/test/configuration_filtered.js
+++ b/api-idee-js/test/configuration_filtered.js
@@ -263,6 +263,22 @@ function fun(IDEE_) {
   IDEE_.config('SQL_WASM_URL', '../../../../node_modules/sql.js/dist/');
 
   /**
+   * MAP Viewer - DPI (Dots per inch)
+   * 
+   * @private
+   * @type {Number}
+   */
+  IDEE.config('DPI', 72);
+
+  /**
+   * MAP Viewer - DPI OGC (Dots per inch for OGC services)
+   * 
+   * @private
+   * @type {Number}
+   */
+  IDEE.config('DPI_OGC', 90.714285714);
+
+  /**
    * Mueve el mapa cuando se hace clic sobre un objeto
    * geográfico, (extract = true) o no (extract = false)
    *


### PR DESCRIPTION
Añade un nuevo nivel de DPI exclusivamente para el cálculo de la escala numérica. Esto es debido a que, el nivel de DPI que tiene por defecto OpenLayers para cálculos de escala interna y el control ScaleLine es 90.714 (derivado de 25.4 / 0.28), mientras que el DPI global que utiliza la librería es 72. Es por ello que se ha definido en el archivo de configuración de API IDEE dos variables:

- DPI: nivel global de DPI (por defecto 72)
- DPI_OGC: nivel de DPI para el cálculo de la escala (por defecto 90.714285714)

Con los cambios realizados ahora la escala coincide con los niveles de OGC:
<img width="458" height="234" alt="image" src="https://github.com/user-attachments/assets/4670c422-1d90-4554-baf1-d622aff9d267" />
<img width="272" height="20" alt="image" src="https://github.com/user-attachments/assets/8512e933-1856-4768-8581-d661d678cd1c" />
<img width="274" height="22" alt="image" src="https://github.com/user-attachments/assets/e90beae0-23aa-45f0-a0c3-60bc1d0af06a" />
<img width="272" height="26" alt="image" src="https://github.com/user-attachments/assets/91fe6a45-db6e-4808-b1a4-a58f4e2676a7" />
