### PR TITLE
Realiza consumo de niveles de escala OGC en el test de cálculo de escala

### DIFF
--- a/api-idee-js/test/playwright/ol/PLAY-24-scale.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-24-scale.spec.js
@@ -16,8 +16,8 @@ test.describe('IDEE.control.Scale', () => {
   });
 
   test('Verificar escala al cambiar el nivel de zoom', async ({ page }) => {
-    const zoomLevel = 7;
-    const expectedScale = 2761266;
+    const zoomLevel = 4;
+    const expectedScale = 34942642;
 
     await page.evaluate(async (zoom) => {
       const zoomElement = document.querySelector('#m-level-number');


### PR DESCRIPTION
Modifica el test PLAY-24 para que realice la comparación de la escala calculada por API IDEE con la escala dada por el TileMatrixSet de OGC para un nivel de zoom 4.