### PR TITLE
Arregla el consumo de servicios WMS con proxy

### DIFF
--- a/api-idee-js/src/facade/js/util/Remote.js
+++ b/api-idee-js/src/facade/js/util/Remote.js
@@ -316,7 +316,7 @@ export const get = (url, data, options) => {
   if (!isNullOrEmpty(options) && 'useProxy' in options) {
     useProxyValue = options.useProxy;
   } else {
-    useProxyValue = null;
+    useProxyValue = useproxy;
   }
 
   const useJsonp = useProxyValue === true

--- a/api-idee-js/test/playwright/ol/PLAY-30-wmcNames.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-30-wmcNames.spec.js
@@ -4,7 +4,7 @@ test.describe('IDEE.layer.WMC', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/test/playwright/ol/basic-ol.html');
     await page.evaluate(() => {
-      // IDEE.proxy(true);
+      IDEE.proxy(true);
       const map = IDEE.map({
         container: 'map',
         projection: 'EPSG:25830*d',

--- a/api-idee-js/test/playwright/ol/PLAY-35-wmc.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-35-wmc.spec.js
@@ -4,7 +4,7 @@ test.describe('IDEE.layer.WMC', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/test/playwright/ol/basic-ol.html');
     await page.evaluate(() => {
-      // IDEE.proxy(true);
+      IDEE.proxy(true);
       const map = IDEE.map({
         container: 'map',
         projection: 'EPSG:3857*m',


### PR DESCRIPTION
Se corrige un condicional para que en caso de que el proxy no venga definido por las opciones, tome el valor global de este en vez de un valor null. También se reactiva el uso del proxy en los test PLAY-30 y PLAY-35.