### PR TITLE
Bug 549 ctrl scale round result

### DIFF
--- a/api-idee-js/src/impl/ol/js/control/Scale.js
+++ b/api-idee-js/src/impl/ol/js/control/Scale.js
@@ -7,6 +7,7 @@ import { getValue } from 'IDEE/i18n/language';
 import * as Dialog from 'IDEE/dialog';
 import Exception from 'IDEE/exception/exception';
 import Control from './Control';
+import { isBoolean } from '../../../../facade/js/util/Utils';
 
 /**
  * Formate un número pasado por parámetro.
@@ -27,19 +28,21 @@ export const formatLongNumber = (num) => {
  * @public
  * @function
  * @param {HTMLElement} container HTML contenedor del control.
- * @param {Number} map Mapa.
+ * @param {Object} map Mapa.
+ * @param {Boolean} exactEscale Devuelve la escala exacta o aproximada.
  * @api stable
  */
-const updateElement = (container, map) => {
-  const containerVariable = container;
+const updateElement = (container, map, exactEscale) => {
   const view = map.getMapImpl().getView();
   const resolution = view.getResolution();
-  const dpi = IDEE.config.DPI_OGC;
-  const num = Utils.getScaleForResolution(resolution, view, dpi);
 
-  if (!isNullOrEmpty(num)) {
-    containerVariable.innerHTML = formatLongNumber(num);
+  const scale = Utils.getScaleForResolution(resolution, exactEscale);
+
+  if (!isNullOrEmpty(scale)) {
+    // eslint-disable-next-line no-param-reassign
+    container.innerHTML = formatLongNumber(scale);
   }
+
   const elem = document.querySelector('#m-level-number');
   if (elem !== null) {
     elem.innerHTML = map.getZoom().toFixed(2);
@@ -65,6 +68,7 @@ class Scale extends Control {
    */
   constructor(options = {}) {
     super();
+    this.exactScale = isBoolean(options.exactScale) ? options.exactScale : false;
     this.facadeMap_ = null;
   }
 
@@ -186,7 +190,7 @@ class Scale extends Control {
   renderCB(mapEvent) {
     const frameState = mapEvent.frameState;
     if (!isNullOrEmpty(frameState)) {
-      updateElement(this.scaleContainer_, this.facadeMap_);
+      updateElement(this.scaleContainer_, this.facadeMap_, this.exactScale);
     }
   }
 

--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -669,19 +669,30 @@ class Utils {
     return Math.trunc(scale);
   }
 
+  static getRoundScale(scale) {
+    let newScale = scale;
+    if (newScale >= 1000 && newScale <= 950000) {
+      newScale = Math.round(newScale / 1000) * 1000;
+    } else if (newScale >= 950000) {
+      newScale = Math.round(newScale / 1000000) * 1000000;
+    } else {
+      newScale = Math.round(newScale);
+    }
+    return newScale;
+  }
+
   /**
    * Este método obtiene la escala para una resolución dada.
    *
    * @function
    * @param {Number} resolution Resolución del mapa.
-   * @param {View} view Vista del mapa.
-   * @param {Number} dpi DPI del mapa (por defecto 72).
-   * @returns {Number} Escala calculada.
+   * @param {Boolean} exact Devuelve la escala exacta o aproximada.
    * @public
    * @api
    */
-  static getScaleForResolution(resolution) {
-    return Math.round(resolution / 0.00028);
+  static getScaleForResolution(resolution, exact) {
+    const scale = Math.round(resolution / 0.00028);
+    return exact ? scale : Math.round(Utils.getRoundScale(scale));
   }
 
   /**

--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -657,18 +657,15 @@ class Utils {
     const ang = pix2[2] - pix2[0];
     // (numero de metros en el mapa / numero de pixeles) / metros por pixel
     let scale = (((mpu * ang) / pix) * 1000) / 0.28;
-    if (!exact === true) {
-      if (scale >= 1000 && scale <= 950000) {
-        scale = Math.round(scale / 1000) * 1000;
-      } else if (scale >= 950000) {
-        scale = Math.round(scale / 1000000) * 1000000;
-      } else {
-        scale = Math.round(scale);
-      }
-    }
+    if (!exact === true) scale = Utils.getRoundScale(scale);
     return Math.trunc(scale);
   }
 
+  /**
+   * Returns an integer representing a valid scale
+   * @param {number} scale
+   * @returns {number}
+   */
   static getRoundScale(scale) {
     let newScale = scale;
     if (newScale >= 1000 && newScale <= 950000) {

--- a/api-idee-js/test/development/CP-0003-controls/CP-002.js
+++ b/api-idee-js/test/development/CP-0003-controls/CP-002.js
@@ -1,9 +1,11 @@
 import { map as Mmap } from 'IDEE/api-idee';
 
+// eslint-disable-next-line no-unused-vars
 const mapa = Mmap({
   container: 'map',
   projection: 'EPSG:3857',
   controls: ['scale*false', 'scaleline', 'panzoom', 'panzoombar'],
+  // controls: ['scale*true', 'scaleline', 'panzoom', 'panzoombar'],
   center: [-443273.10081370454, 4757481.749296248],
   zoom: 6,
 });


### PR DESCRIPTION
Se rescata la anterior funcionalidad para que el control de escala pueda redondear, para ello se genera un método nuevo en útils para redondeo de escala, posteriormente se aplica un pequeño refactor.