### PR TITLE
fix: change scale round from default to not rounded

### DIFF
--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -689,7 +689,7 @@ class Utils {
    */
   static getScaleForResolution(resolution, exact) {
     const scale = Math.round(resolution / 0.00028);
-    return exact ? scale : Math.round(Utils.getRoundScale(scale));
+    return exact ? Math.round(Utils.getRoundScale(scale)) : scale;
   }
 
   /**

--- a/api-idee-js/test/development/CP-0003-controls/CP-002.js
+++ b/api-idee-js/test/development/CP-0003-controls/CP-002.js
@@ -4,7 +4,7 @@ import { map as Mmap } from 'IDEE/api-idee';
 const mapa = Mmap({
   container: 'map',
   projection: 'EPSG:3857',
-  controls: ['scale*false', 'scaleline', 'panzoom', 'panzoombar'],
+  controls: ['scale', 'scaleline', 'panzoom', 'panzoombar'],
   // controls: ['scale*true', 'scaleline', 'panzoom', 'panzoombar'],
   center: [-443273.10081370454, 4757481.749296248],
   zoom: 6,


### PR DESCRIPTION
Changes getScaleForResolution, param exact is now used as well