### PR TITLE
Soluciona el cálculo de escala sobre la proyección EPSG:3857

### DIFF
--- a/api-idee-js/src/configuration.js
+++ b/api-idee-js/src/configuration.js
@@ -333,7 +333,7 @@ params.forEach((param) => {
    * @private
    * @type {Number}
    */
-  IDEE.config('DPI_OGC', 90.714285714);
+  IDEE.config('DPI_OGC', 25.4 / 0.28);
 
   /**
    * Mueve el mapa cuando se hace clic sobre un objeto

--- a/api-idee-js/src/impl/ol/js/control/Scale.js
+++ b/api-idee-js/src/impl/ol/js/control/Scale.js
@@ -36,7 +36,7 @@ const updateElement = (container, map, exactEscale) => {
   const view = map.getMapImpl().getView();
   const resolution = view.getResolution();
 
-  const scale = Utils.getScaleForResolution(resolution, exactEscale);
+  const scale = Utils.getScaleForResolution(resolution, view, IDEE.config.DPI_OGC, exactEscale);
 
   if (!isNullOrEmpty(scale)) {
     // eslint-disable-next-line no-param-reassign
@@ -161,6 +161,7 @@ class Scale extends Control {
             this.scaleContainer_.textContent = scaleText;
             const view = this.facadeMap_.getMapImpl().getView();
             const resolution = Utils.getCurrentScale(
+              view,
               scaleText,
               IDEE.config.DPI_OGC,
             );

--- a/api-idee-js/src/impl/ol/js/projections.js
+++ b/api-idee-js/src/impl/ol/js/projections.js
@@ -82,6 +82,7 @@ const proj3857 = {
   ],
   units: 'm',
   metersPerUnit: 1,
+  getPointResolution: (resolution, point) => resolution / Math.cosh(point[1] / 6378137),
   datum: 'WGS 84',
   proj: 'Pseudo-Mercator',
   global: true,
@@ -596,6 +597,7 @@ const addProjections = (projs, checkDuplicates = true) => {
         extent: projection.extent,
         units: projection.units,
         metersPerUnit: projection.metersPerUnit,
+        getPointResolution: projection.getPointResolution,
         axisOrientation: projection.axisOrientation,
         global: projection.global,
       });

--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -11,6 +11,7 @@ import {
   get as getProj,
   getTransform,
   transformExtent,
+  getPointResolution,
 } from 'ol/proj';
 import OLFeature from 'ol/Feature';
 import WKB from 'ol/format/WKB';
@@ -683,13 +684,20 @@ class Utils {
    *
    * @function
    * @param {Number} resolution Resolución del mapa.
+   * @param {View} view Vista del mapa.
+   * @param {Number} dpi DPI del mapa.
    * @param {Boolean} exact Devuelve la escala exacta o aproximada.
    * @public
    * @api
    */
-  static getScaleForResolution(resolution, exact) {
-    const scale = Math.round(resolution / 0.00028);
-    return exact ? Math.round(Utils.getRoundScale(scale)) : scale;
+  static getScaleForResolution(resolution, view, dpi, exact) {
+    const projection = view.getProjection();
+    const center = view.getCenter();
+    const inchesPerMeter = 1000 / 25.4;
+    const pointResolution = getPointResolution(projection, resolution, center, 'm');
+    const scale = pointResolution * inchesPerMeter * dpi;
+
+    return exact ? Math.round(scale) : Math.round(Utils.getRoundScale(scale));
   }
 
   /**
@@ -704,22 +712,16 @@ class Utils {
    * @public
    * @api
    */
-  static getCurrentScale(inputValue, dpi) {
-    const inchesPerMeter = 39.3700787;
-    const scale = parseFloat(inputValue.replace(/\./g, ''));
-    const calculateResolution = (targetScale) => {
-      let resolution = targetScale / (inchesPerMeter * dpi);
+  static getCurrentScale(view, inputValue, dpi) {
+    const targetScale = parseFloat(inputValue.replace(/\./g, ''));
+    const projection = view.getProjection();
+    const metersPerUnit = projection.getMetersPerUnit();
+    const dotsPerMeter = dpi / 0.0254;
+    const resolution = targetScale / (metersPerUnit * dotsPerMeter);
+    const center = view.getCenter();
+    const pointResolution = getPointResolution(projection, 1, center);
 
-      for (let i = 0; i < 3; i + 1) {
-        const currentScale = this.getScaleForResolution(resolution);
-        const error = targetScale - currentScale;
-        resolution *= (targetScale / currentScale);
-
-        if (Math.abs(error) < 1) break;
-      }
-      return resolution;
-    };
-    return calculateResolution(scale);
+    return resolution / pointResolution;
   }
 
   /**

--- a/api-idee-js/test/playwright/ol/PLAY-24-scale.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-24-scale.spec.js
@@ -1,24 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('IDEE.control.Scale', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/test/playwright/ol/basic-ol.html');
+  const zooms = [4, 5, 6, 7];
+  const ogcScales = [34942642, 17471321, 8735660, 4367830];
+  const approxScales = [35000000, 17000000, 9000000, 4000000];
 
-    await page.evaluate(() => {
-      const map = IDEE.map({
-        container: 'map',
-        center: [-438581.6802781217, 4455610.713817699],
-        controls: ['scale'],
-      });
-
-      window.map = map;
-    });
-  });
-
-  test('Verificar escala al cambiar el nivel de zoom', async ({ page }) => {
-    const zoomLevel = 4;
-    const expectedScale = 34942642;
-
+  const setZoomAndGetScale = async (page, zoomLevel) => {
     await page.evaluate(async (zoom) => {
       const zoomElement = document.querySelector('#m-level-number');
       zoomElement.textContent = zoom.toString();
@@ -33,11 +20,61 @@ test.describe('IDEE.control.Scale', () => {
       });
     }, zoomLevel);
 
-    await page.waitForTimeout(2000);
-    const finalScale = await page.evaluate(() => {
+    await page.waitForTimeout(5000);
+
+    return page.evaluate(() => {
       const scaleText = document.querySelector('#m-scale-span').textContent;
       return parseInt(scaleText.replace(/\./g, ''), 10);
     });
-    await expect(finalScale).toBe(expectedScale);
+  };
+
+  test.describe('scale*true - escalas OGC exactas', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/test/playwright/ol/basic-ol.html');
+
+      await page.evaluate(() => {
+        const map = IDEE.map({
+          container: 'map',
+          center: [0, 0],
+          controls: ['scale*true'],
+        });
+        window.map = map;
+      });
+    });
+
+    for (let i = 0; i < zooms.length; i++) {
+      const zoom = zooms[i];
+      const expectedScale = ogcScales[i];
+
+      test(`Zoom ${zoom} → escala esperada 1:${expectedScale.toLocaleString('es-ES')}`, async ({ page }) => {
+        const finalScale = await setZoomAndGetScale(page, zoom);
+        expect(finalScale).toBe(expectedScale);
+      });
+    }
+  });
+
+  test.describe('scale*false - escalas aproximadas', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/test/playwright/ol/basic-ol.html');
+
+      await page.evaluate(() => {
+        const map = IDEE.map({
+          container: 'map',
+          center: [0, 0],
+          controls: ['scale*false'],
+        });
+        window.map = map;
+      });
+    });
+
+    for (let i = 0; i < zooms.length; i++) {
+      const zoom = zooms[i];
+      const expectedScale = approxScales[i];
+
+      test(`Zoom ${zoom} → escala esperada 1:${expectedScale.toLocaleString('es-ES')}`, async ({ page }) => {
+        const finalScale = await setZoomAndGetScale(page, zoom);
+        expect(finalScale).toBe(expectedScale);
+      });
+    }
   });
 });


### PR DESCRIPTION
El motivo por el cuál el control Scale de API IDEE y el control ScaleLine de OpenLayers obtenían erróneamente la escala es porque se registraba la proyección EPSG:3857 omitiendo información relevante.
Esta proyección ya es registrada por defecto por OpenLayers:
<img width="656" height="175" alt="image" src="https://github.com/user-attachments/assets/c7d0298e-a2f8-404b-b76a-c8f43a3bfa84" />
Pero en API IDEE se vuelve a registrar y hay parámetros que no se tienen en cuenta, como por ejemplo _getPointResolutionFunc__, _defaultTileGrid__ o _worldExtent__. En la proyección EPSG:3857 la función getPointResolution es la siguiente:
**ƒ (t,e){return t/Math.cosh(e[1]/yi)}**, donde:

1. t = resolución de la vista del mapa
2. e = coordenadas del centro de la vista
3. yi = constante del semieje mayor del elipsoide WGS84 (radio ecuatorial de WGS84)

pero al registrarla de nuevo sin definir este parámetro, OpenLayers asigna una función por defecto, causando el cálculo erróneo de la escala.

Por último se actualiza el test del cálculo de la escala para que compruebe los cálculos en caso de que se el parámetro _exact_ del control Scale esté activo o inactivo.
