### PR TITLE
Declara la función zDirection en los servicios teselados para redondear el cambio de nivel de tesela

### DIFF
--- a/api-idee-js/src/facade/js/util/Utils.js
+++ b/api-idee-js/src/facade/js/util/Utils.js
@@ -341,6 +341,23 @@ export const getWMTSGetCapabilitiesUrl = (serverUrl, version) => {
 };
 
 /**
+ * Esta función devuelve una función para el parámetro zDirection de los servicios teselados.
+ * @returns {Function} Función para el parámetro zDirection de los servicios teselados.
+ */
+export const getZDirectionFunction = () => {
+  return ((value, high, low) => {
+    const midpoint = low * Math.sqrt(high / low);
+    const diff = value - midpoint;
+    const epsilon = 1e-6;
+
+    if (Math.abs(diff) < epsilon) {
+      return 0;
+    }
+    return diff;
+  });
+};
+
+/**
  * Esta función genera una resolución máxima y mínima.
  *
  * @function

--- a/api-idee-js/src/impl/ol/js/layer/GeoPackageTile.js
+++ b/api-idee-js/src/impl/ol/js/layer/GeoPackageTile.js
@@ -2,7 +2,7 @@
  * @module IDEE/impl/layer/GeoPackageTile
  */
 import {
-  isNullOrEmpty,
+  isNullOrEmpty, getZDirectionFunction,
 } from 'IDEE/util/Utils';
 import { DEFAULT_WHITE_TILE } from 'IDEE/provider/Tile';
 import * as EventType from 'IDEE/event/eventtype';
@@ -65,6 +65,11 @@ class GeoPackageTile extends Layer {
      * Función de carga de tiles.
      */
     this.tileLoadFunction = userParameters.tileLoadFunction || null;
+
+    /**
+     * Función de dirección Z para la carga de teselas.
+     */
+    this.zDirection = userParameters.zDirection || getZDirectionFunction();
 
     /**
       * Máxima extensión de la capa.
@@ -169,6 +174,7 @@ class GeoPackageTile extends Layer {
         projection,
         tileUrlFunction: (coord) => `{${coord[2]}},{${coord[0]}},{${coord[1]}}`,
         tileLoadFunction: (tile) => tileLoadFn(tile, this),
+        zDirection: this.zDirection,
       }),
     });
 

--- a/api-idee-js/src/impl/ol/js/layer/MBTiles.js
+++ b/api-idee-js/src/impl/ol/js/layer/MBTiles.js
@@ -1,7 +1,9 @@
 /**
  * @module IDEE/impl/layer/MBTiles
  */
-import { isNullOrEmpty, isFunction, extend } from 'IDEE/util/Utils';
+import {
+  isNullOrEmpty, isFunction, extend, getZDirectionFunction,
+} from 'IDEE/util/Utils';
 import { get as getProj, transformExtent } from 'ol/proj';
 import OLLayerTile from 'ol/layer/Tile';
 import TileGrid from 'ol/tilegrid/TileGrid';
@@ -108,6 +110,11 @@ class MBTiles extends Layer {
      * MBTiles tileLoadFunction: Función de carga de la tesela proporcionada por el usuario.
      */
     this.tileLoadFunction = userParameters.tileLoadFunction || null;
+
+    /**
+     * MBTiles zDirection: Función de dirección Z para la carga de teselas.
+     */
+    this.zDirection = userParameters.zDirection || getZDirectionFunction();
 
     /**
      * MBTiles url: Url del fichero o servicio que genera el MBTiles.
@@ -325,6 +332,7 @@ class MBTiles extends Layer {
           origin: getBottomLeft(opts.sourceExtent),
           resolutions: opts.resolutions,
         }),
+        zDirection: this.zDirection,
       });
     }
     this.olLayer.setSource(source);

--- a/api-idee-js/src/impl/ol/js/layer/MBTilesVector.js
+++ b/api-idee-js/src/impl/ol/js/layer/MBTilesVector.js
@@ -2,7 +2,9 @@
 /**
  * @module IDEE/impl/layer/MBTilesVector
  */
-import { isNullOrEmpty, extend, isObject } from 'IDEE/util/Utils';
+import {
+  isNullOrEmpty, extend, isObject, getZDirectionFunction,
+} from 'IDEE/util/Utils';
 import { get as getProj, transformExtent } from 'ol/proj';
 // import { inflate } from 'pako';
 // import OLLayerTile from 'ol/layer/Tile';
@@ -114,6 +116,11 @@ class MBTilesVector extends Vector {
      * vectorial proporcionada por el usuario.
      */
     this.tileLoadFunction = userParameters.tileLoadFunction || null;
+
+    /**
+     * MBTilesVector zDirection. Función de dirección Z para la carga de teselas.
+     */
+    this.zDirection = userParameters.zDirection || getZDirectionFunction();
 
     /**
      * MBTilesVector url: Url del fichero o servicio que genera el MBTilesVector.
@@ -299,6 +306,7 @@ class MBTilesVector extends Vector {
         origin: getBottomLeft(opts.sourceExtent),
         resolutions: opts.resolutions,
       }),
+      zDirection: this.zDirection,
     }));
 
     this.olLayer.setExtent(this.maxExtent_ || opts.sourceExtent);

--- a/api-idee-js/src/impl/ol/js/layer/MVT.js
+++ b/api-idee-js/src/impl/ol/js/layer/MVT.js
@@ -5,7 +5,9 @@
 import OLSourceVectorTile from 'ol/source/VectorTile';
 import OLLayerVectorTile from 'ol/layer/VectorTile';
 // import { get as getProj } from 'ol/proj';
-import { isNullOrEmpty, extend, isObject } from 'IDEE/util/Utils';
+import {
+  isNullOrEmpty, extend, isObject, getZDirectionFunction,
+} from 'IDEE/util/Utils';
 import * as EventType from 'IDEE/event/eventtype';
 import TileEventType from 'ol/source/TileEventType';
 import TileState from 'ol/TileState';
@@ -114,6 +116,13 @@ class MVT extends Vector {
     this.tileLoadFunction = vendorOptions?.tileLoadFunction;
 
     /**
+     * MVT zDirection. Función de dirección Z para la carga de teselas.
+     * @private
+     * @type {Function}
+     */
+    this.zDirection = vendorOptions?.zDirection || getZDirectionFunction();
+
+    /**
      * MVT layers_. Otras capas.
      */
     this.layers_ = parameters.layers;
@@ -199,6 +208,7 @@ class MVT extends Vector {
       url,
       projection: this.projection_,
       tileLoadFunction: this.tileLoadFunction,
+      zDirection: this.zDirection,
     });
 
     // register events in order to fire the LOAD event

--- a/api-idee-js/src/impl/ol/js/layer/OSM.js
+++ b/api-idee-js/src/impl/ol/js/layer/OSM.js
@@ -4,7 +4,7 @@
 import FacadeOSM from 'IDEE/layer/OSM';
 import * as LayerType from 'IDEE/layer/Type';
 import {
-  isUndefined, isNullOrEmpty, generateResolutionsFromExtent, extend,
+  isUndefined, isNullOrEmpty, generateResolutionsFromExtent, getZDirectionFunction, extend,
 } from 'IDEE/util/Utils';
 import * as EventType from 'IDEE/event/eventtype';
 import OLLayerTile from 'ol/layer/Tile';
@@ -96,6 +96,11 @@ class OSM extends Layer {
      * OMS tileLoadFunction. Función de carga de tiles.
      */
     this.tileLoadFunction = vendorOptions?.tileLoadFunction;
+
+    /**
+     * OSM zDirection. Función de dirección Z para la carga de teselas.
+     */
+    this.zDirection = vendorOptions?.zDirection || getZDirectionFunction();
 
     /**
      * OSM zIndex_. Índice de la capa, (+5).
@@ -257,10 +262,12 @@ class OSM extends Layer {
         newSource = new SourceXYZ({
           url: this.url,
           tileLoadFunction: this.tileLoadFunction,
+          zDirection: this.zDirection,
         });
       } else {
         newSource = new SourceOSM({
           tileLoadFunction: this.tileLoadFunction,
+          zDirection: this.zDirection,
         });
       }
       this.olLayer.setSource(newSource);

--- a/api-idee-js/src/impl/ol/js/layer/WMS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WMS.js
@@ -4,8 +4,8 @@
  */
 import OLSourceImageWMS from 'ol/source/ImageWMS';
 import {
-  isNull, isArray, isNullOrEmpty, addParameters, getWMSGetCapabilitiesUrl, fillResolutions,
-  getResolutionFromScale, generateResolutionsFromExtent, extend,
+  isNull, isArray, isNullOrEmpty, addParameters, getWMSGetCapabilitiesUrl, getZDirectionFunction,
+  fillResolutions, getResolutionFromScale, generateResolutionsFromExtent, extend,
 } from 'IDEE/util/Utils';
 import FacadeLayerBase from 'IDEE/layer/Layer';
 import * as LayerType from 'IDEE/layer/Type';
@@ -116,6 +116,13 @@ class WMS extends LayerBase {
      * @type {Function}
      */
     this.tileLoadFunction = vendorOptions?.tileLoadFunction;
+
+    /**
+     * WMS zDirection. Función de dirección Z para la carga de teselas.
+     * @private
+     * @type {Function}
+     */
+    this.zDirection = vendorOptions?.zDirection || getZDirectionFunction();
 
     /**
      * WMS extentPromise. Extensión de la capa, promesa.
@@ -650,6 +657,7 @@ class WMS extends LayerBase {
       const opacity = this.opacity_;
       const zIndex = this.zIndex_;
       const tileLoadFunction = this.tileLoadFunction;
+      const zDirection = this.zDirection;
       if (this.tiled === true) {
         const tileGrid = (this.useCapabilities)
           ? new OLTileGrid({ resolutions, extent, origin: getBottomLeft(extent) })
@@ -665,6 +673,7 @@ class WMS extends LayerBase {
           opacity,
           zIndex,
           tileLoadFunction,
+          zDirection,
         });
       } else {
         olSource = new ImageWMS({

--- a/api-idee-js/src/impl/ol/js/layer/WMTS.js
+++ b/api-idee-js/src/impl/ol/js/layer/WMTS.js
@@ -2,8 +2,8 @@
  * @module IDEE/impl/layer/WMTS
  */
 import {
-  isNull, isArray, isNullOrEmpty, addParameters, getWMTSGetCapabilitiesUrl, getResolutionFromScale,
-  extend,
+  isNull, isArray, isNullOrEmpty, addParameters, getWMTSGetCapabilitiesUrl, getZDirectionFunction,
+  getResolutionFromScale, extend,
 } from 'IDEE/util/Utils';
 import { default as OLSourceWMTS, optionsFromCapabilities } from 'ol/source/WMTS';
 // import { optionsFromCapabilities } from 'patches';
@@ -84,11 +84,18 @@ class WMTS extends LayerBase {
     this.getCapabilitiesPromise_ = null;
 
     /**
-     * WMS tileLoadFunction. Función de carga de tiles.
+     * WMTS tileLoadFunction. Función de carga de tiles.
      * @private
      * @type {Function}
      */
     this.tileLoadFunction = vendorOptions?.tileLoadFunction;
+
+    /**
+     * WMTS zDirection. Función de dirección Z.
+     * @private
+     * @type {Function}
+     */
+    this.zDirection = vendorOptions?.zDirection || getZDirectionFunction();
 
     /**
      * WMTS minZoom. Minimum zoom applicable to the layer.
@@ -233,6 +240,7 @@ class WMTS extends LayerBase {
           }),
           extent,
           tileLoadFunction: this.tileLoadFunction,
+          zDirection: this.zDirection,
         });
         this.olLayer.setSource(newSource);
       });
@@ -290,6 +298,7 @@ class WMTS extends LayerBase {
           extent,
           crossOrigin: this.crossOrigin,
           tileLoadFunction: this.tileLoadFunction,
+          zDirection: this.zDirection,
         }, true);
         wmtsSource = new OLSourceWMTS(options);
       }
@@ -355,6 +364,7 @@ class WMTS extends LayerBase {
           projection: getProj(this.map.getProjection().code),
           tileGrid,
           tileLoadFunction: this.tileLoadFunction,
+          zDirection: this.zDirection,
         });
       }
       this.facadeLayer_.setFormat(format);

--- a/api-idee-js/src/impl/ol/js/layer/XYZ.js
+++ b/api-idee-js/src/impl/ol/js/layer/XYZ.js
@@ -1,7 +1,7 @@
 /**
  * @module IDEE/impl/layer/XYZ
  */
-import { isNullOrEmpty, extend } from 'IDEE/util/Utils';
+import { isNullOrEmpty, extend, getZDirectionFunction } from 'IDEE/util/Utils';
 import OLTileLayer from 'ol/layer/Tile';
 import { get as getProj } from 'ol/proj';
 import XYZSource from 'ol/source/XYZ';
@@ -121,6 +121,12 @@ class XYZ extends Layer {
     this.tileGridMaxZoom = userParameters.tileGridMaxZoom;
 
     /**
+     * XYZ zDirection.
+     * Función de dirección Z para la carga de teselas.
+     */
+    this.zDirection = vendorOptions?.zDirection || getZDirectionFunction();
+
+    /**
      * XYZ displayInLayerSwitcher:
      * Mostrar en el selector de capas.
      */
@@ -187,6 +193,7 @@ class XYZ extends Layer {
         url: this.url,
         tileSize: this.getTileSize(),
         crossOrigin: this.crossOrigin,
+        zDirection: this.zDirection,
       });
     }
     this.olLayer.setSource(source);


### PR DESCRIPTION
En _Utils_ se declara la función getZDirectionFunction donde se define la función encargada de calcular un valor, el cuál:
- Si es positivo, se utilizará la resolución más alta (Z más baja) más cercana.
- Si es negativo, se utilizará la resolución más baja (Z más alta) más cercana.
A continuación se define el parámetro [ZDirection](https://openlayers.org/en/latest/apidoc/module-ol_tilegrid_TileGrid-TileGrid.html#getZForResolution) en el _source_ de todos los servicios teselados. De esta manera se logra que el cambio de nivel de tesela se comporte como se requería. Por ejemplo:
Frontera x.49 --> nivel x
Frontera x.50 --> nivel x+1
