### PR TITLE
Error al cambiar proyeccion en mousesrs, infocoordinates y printviewmanagement

### DIFF
--- a/api-idee-js/src/impl/ol/js/projections.js
+++ b/api-idee-js/src/impl/ol/js/projections.js
@@ -59,6 +59,7 @@ const proj3042 = {
   codes: ['EPSG:3042', 'urn:ogc:def:crs:EPSG::3042', 'http://www.opengis.net/gml/srs/epsg.xml#3042'],
   units: 'm',
   metersPerUnit: 1,
+  datum: 'GRS80 (ETRS89)',
 };
 
 /**
@@ -679,7 +680,11 @@ const getDefProjection = async (code) => {
  * @api
  */
 const setNewProjection = async (projection) => {
-  const code = getCode(projection);
+  let projName = projection;
+  if (!projection.startsWith('EPSG:')) {
+    projName = `EPSG:${projection}`;
+  }
+  const code = getCode(projName);
   const defProjectionRaw = await getDefProjection(code);
   const defProjection = defProjectionRaw.replace(/\+nadgrids=[^\s]+/, '').trim();
   const url = `https://epsg.io/${code}.wkt2`;
@@ -696,7 +701,7 @@ const setNewProjection = async (projection) => {
     extent: jsonResponse.USAGE.BBOX,
     codes: [`${Object.keys(jsonResponse.ID)[0]}:${jsonResponse.ID[Object.keys(jsonResponse.ID)[0]]}`],
     units: refactorUnits(Object.keys(jsonResponse.AXIS[0].LENGTHUNIT)[0]),
-    datum: jsonResponse.BASEGEOGCRS.DATUM.name,
+    datum: jsonResponse.BASEGEOGCRS.name,
     proj: jsonResponse.name,
     coordRefSys: `http://www.opengis.net/def/crs/EPSG/0/${code}`,
   };

--- a/api-idee-js/src/plugins/infocoordinates/src/facade/js/infocoordinatescontrol.js
+++ b/api-idee-js/src/plugins/infocoordinates/src/facade/js/infocoordinatescontrol.js
@@ -56,6 +56,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
   createView(map) {
     this.map_ = map;
     this.selectedProjection = this.map_.getProjection().code;
+    this.isProjGeographic = this.getImpl().isProjGeographic(this.selectedProjection);
     if (!IDEE.template.compileSync) { // JGL: retrocompatibilidad API IDEE
       IDEE.template.compileSync = (string, options) => {
         let templateCompiled;
@@ -83,6 +84,8 @@ export default class InfocoordinatesControl extends IDEE.Control {
           hasHelp: this.helpUrl !== undefined && IDEE.utils.isUrl(this.helpUrl),
           helpUrl: this.helpUrl,
           projections: this.projections,
+          datum: this.getImpl().datumCalc(this.selectedProjection),
+          geographicProj: this.isProjGeographic,
           translations: {
             title: getValue('title'),
             point: getValue('point'),
@@ -124,6 +127,10 @@ export default class InfocoordinatesControl extends IDEE.Control {
       html.querySelector('#m-infocoordinates-buttonRemovePoint').addEventListener('click', this.removePoint.bind(this));
       html.querySelector('#m-infocoordinates-copylatlon').addEventListener('click', this.copylatlon.bind(this));
       html.querySelector('#m-infocoordinates-copyxy').addEventListener('click', this.copyxy.bind(this));
+      (this.isProjGeographic
+        ? html.querySelector('#m-infocoordinates-geo-coords')
+        : html.querySelector('#m-infocoordinates-utm-coords')
+      ).classList.remove('noDisplay');
     });
   }
 
@@ -489,7 +496,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
     const selector = document.querySelector('#m-infocoordinates-srs-selector');
 
     // Cojo el srs seleccionado en el select
-    const selectSRS = inputSRS.value;
+    const selectSRS = !inputSRS.value.startsWith('EPSG:') ? `EPSG:${inputSRS.value}` : inputSRS.value;
 
     // Cojo el formato de las coordenadas geográficas
     const formatGMS = document.getElementById('m-infocoordinates-buttonConversorFormat').checked;
@@ -504,6 +511,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
         this.decimalGEOcoord,
         this.decimalUTMcoord,
       );
+      this.selectedProjection = selectSRS;
     } catch (error) {
       try {
         await IDEE.impl.ol.js.projections.setNewProjection(selectSRS);
@@ -514,6 +522,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
           this.decimalGEOcoord,
           this.decimalUTMcoord,
         );
+        this.selectedProjection = selectSRS;
       } catch (err) {
         pointDataOutput = this.getImpl().getCoordinates(
           featureSelected,
@@ -522,11 +531,18 @@ export default class InfocoordinatesControl extends IDEE.Control {
           this.decimalGEOcoord,
           this.decimalUTMcoord,
         );
-        inputSRS.value = this.selectedProjection;
         IDEE.dialog.error(`${getValue('exception.srs')} ${this.selectedProjection}`);
       }
     }
-
+    inputSRS.value = this.selectedProjection;
+    this.isProjGeographic = this.getImpl().isProjGeographic(this.selectedProjection);
+    if (this.isProjGeographic) {
+      document.getElementById('m-infocoordinates-geo-coords').classList.remove('noDisplay');
+      document.getElementById('m-infocoordinates-utm-coords').classList.add('noDisplay');
+    } else {
+      document.getElementById('m-infocoordinates-geo-coords').classList.add('noDisplay');
+      document.getElementById('m-infocoordinates-utm-coords').classList.remove('noDisplay');
+    }
     this.projections = IDEE.impl.ol.js.projections.getSupportedProjs();
     selector.innerHTML = `
       <li><a class="m-infocoordinates-option-disabled" href="#" value="default" tabindex="-1" disabled>
@@ -642,7 +658,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
   }
 
   copyAllPoints() {
-    let printDocument = `${getValue('point').replace(':', '')},Long,Lat,Alt,EPSG,X,Y,Alt,EPSG\n`;
+    let printDocument = `${getValue('point').replace(':', '')},${this.isProjGeographic ? 'Long,Lat' : 'X,Y'},Alt,EPSG\n`;
     for (let i = 0; i < this.layerFeatures.getImpl().getFeatures(true).length; i += 1) {
       const featureSelected = this.layerFeatures.getImpl().getFeatures(true)[i];
       const alt = featureSelected.getAttributes().Altitude !== undefined ? parseFloat(featureSelected.getAttributes().Altitude) : '-';
@@ -661,26 +677,18 @@ export default class InfocoordinatesControl extends IDEE.Control {
         this.decimalGEOcoord,
         this.decimalUTMcoord,
       );
-      const proj = pointDataOutput.projectionUTM.code;
 
-      const coordinatesGEO = [
-        pointDataOutput.projectionGEO.coordinatesGEO.longitude,
-        pointDataOutput.projectionGEO.coordinatesGEO.latitude,
-      ];
+      const coordinates = this.isProjGeographic
+        ? [
+          pointDataOutput.projectionGEO.coordinatesGEO.longitude,
+          pointDataOutput.projectionGEO.coordinatesGEO.latitude,
+        ]
+        : [
+          pointDataOutput.projectionUTM.coordinatesUTM.coordX,
+          pointDataOutput.projectionUTM.coordinatesUTM.coordY,
+        ];
 
-      const coordinatesUTM = [
-        pointDataOutput.projectionUTM.coordinatesUTM.coordX,
-        pointDataOutput.projectionUTM.coordinatesUTM.coordY,
-      ];
-
-      let projection;
-      if (proj.indexOf('25829') > -1 || proj.indexOf('25830') > -1 || proj.indexOf('25831') > -1) {
-        projection = ',EPSG:4258';
-      } else {
-        projection = ',EPSG:4326';
-      }
-
-      const result = `${i + 1},${coordinatesGEO},${alt.toString()}${projection.trim()},${coordinatesUTM},${alt.toString()},${proj}\n`;
+      const result = `${i + 1},${coordinates},${alt.toString()},${this.selectedProjection}\n`;
 
       printDocument = printDocument.concat(result);
     }
@@ -692,7 +700,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
   importAllPoints() {
     const printDocument = [];
     if (this.outputDownloadFormat === 'csv') {
-      printDocument.push(`${getValue('point').replace(':', '')},Long,Lat,Alt,EPSG,X,Y,Alt,EPSG\n`);
+      printDocument.push(`${getValue('point').replace(':', '')},${this.isProjGeographic ? 'Long,Lat' : 'X,Y'},Alt,EPSG\n`);
     }
     for (let i = 0; i < this.layerFeatures.getImpl().getFeatures(true).length; i += 1) {
       const featureSelected = this.layerFeatures.getImpl().getFeatures(true)[i];
@@ -712,32 +720,24 @@ export default class InfocoordinatesControl extends IDEE.Control {
         this.decimalGEOcoord,
         this.decimalUTMcoord,
       );
-      const proj = pointDataOutput.projectionUTM.code;
 
-      const coordinatesGEO = [
-        pointDataOutput.projectionGEO.coordinatesGEO.longitude,
-        pointDataOutput.projectionGEO.coordinatesGEO.latitude,
-      ];
-
-      const coordinatesUTM = [
-        pointDataOutput.projectionUTM.coordinatesUTM.coordX,
-        pointDataOutput.projectionUTM.coordinatesUTM.coordY,
-      ];
-
-      let projection = 'EPSG:4326: ';
-      if (proj.indexOf('25829') > -1 || proj.indexOf('25830') > -1 || proj.indexOf('25831') > -1) {
-        projection = 'EPSG:4258: ';
-      }
+      const coordinates = this.isProjGeographic
+        ? [
+          pointDataOutput.projectionGEO.coordinatesGEO.longitude,
+          pointDataOutput.projectionGEO.coordinatesGEO.latitude,
+        ]
+        : [
+          pointDataOutput.projectionUTM.coordinatesUTM.coordX,
+          pointDataOutput.projectionUTM.coordinatesUTM.coordY,
+        ];
 
       if (this.outputDownloadFormat === 'csv') {
-        printDocument.push(`${i + 1},${coordinatesGEO},${alt.toString()},${projection.trim().slice(0, -1)},${coordinatesUTM},${alt.toString()},${proj}\n`);
+        printDocument.push(`${i + 1},${coordinates},${alt.toString()},${this.selectedProjection}\n`);
       } else {
         printDocument.push(`${getValue('point').replace(':', ' ')}${i + 1}: \n`);
-        printDocument.push(projection);
+        printDocument.push(`${this.selectedProjection}: `);
 
-        printDocument.push(`[${coordinatesGEO},${alt}]\n`);
-        printDocument.push(`${proj}: `);
-        printDocument.push(`[${coordinatesUTM},${alt}]\n`);
+        printDocument.push(`[${coordinates},${alt}]\n`);
       }
     }
 
@@ -768,7 +768,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
       for (let i = 0; i < this.layerFeatures.getImpl().getFeatures(true).length; i += 1) {
         const pos = this.layerFeatures.getImpl()
           .getFeatures(true)[i].getImpl().getFeature().getProperties().coordinates;
-        const varUTM = this.calculateUTMcoordinates(i + 1);
+        const varUTM = this.calculateCoordinates(i + 1);
         const altitude = `${parseFloat(this.layerFeatures.getImpl().getFeatures(true)[i].getImpl().getFeature().getProperties().Altitude).toFixed(2)}`.replace('.', ',');
         const textHTML = `<div class="m-popup m-collapsed" style="padding: 5px 5px 5px 5px !important;background-color: rgba(255, 255, 255, 0.7) !important;">
               <div class="contenedorCoordPunto">
@@ -811,7 +811,7 @@ export default class InfocoordinatesControl extends IDEE.Control {
     }
   }
 
-  calculateUTMcoordinates(numPoint) {
+  calculateCoordinates(numPoint) {
     const featureSelected = this.layerFeatures.getFeatureById(numPoint);
     // Cojo el srs seleccionado en el select
     const selectSRS = document.querySelector('.m-infocoordinates-input-select').value;
@@ -828,8 +828,15 @@ export default class InfocoordinatesControl extends IDEE.Control {
       this.decimalUTMcoord,
     );
 
-    return [pointDataOutput.projectionUTM.coordinatesUTM.coordX,
-      pointDataOutput.projectionUTM.coordinatesUTM.coordY];
+    return this.isProjGeographic
+      ? [
+        pointDataOutput.projectionGEO.coordinatesGEO.longitude,
+        pointDataOutput.projectionGEO.coordinatesGEO.latitude,
+      ]
+      : [
+        pointDataOutput.projectionUTM.coordinatesUTM.coordX,
+        pointDataOutput.projectionUTM.coordinatesUTM.coordY,
+      ];
   }
 
   removeAllDisplaysPoints() {

--- a/api-idee-js/src/plugins/infocoordinates/src/impl/ol/js/infocoordinatescontrol.js
+++ b/api-idee-js/src/plugins/infocoordinates/src/impl/ol/js/infocoordinatescontrol.js
@@ -80,14 +80,14 @@ export default class InfocoordinatesControl extends IDEE.impl.Control {
   }
 
   datumCalc(srs) {
-    let datum = 'ETRS89';
-    if (srs.indexOf('3857') > -1) {
-      datum = 'WGS84';
-    } else if (srs.indexOf('4083') > -1) {
-      datum = 'REGCAN95';
-    }
+    return IDEE.impl.ol.js.projections.getSupportedProjs()
+      .find((p) => p.codes.includes(srs))
+      .datum;
+  }
 
-    return datum;
+  isProjGeographic(srs) {
+    return IDEE.impl.ol.js.projections.getSupportedProjs()
+      .find((p) => p.codes.includes(srs)).units === 'd';
   }
 
   readAltitudeFromElevationProcess(coordinates, srcMapa) {

--- a/api-idee-js/src/plugins/infocoordinates/src/templates/infocoordinates.html
+++ b/api-idee-js/src/plugins/infocoordinates/src/templates/infocoordinates.html
@@ -23,15 +23,32 @@
                         </tr>
                         <tr tabindex="0">
                             <td>{{translations.datum}}</td>
-                            <td id="m-infocoordinates-datum" colspan="2">ETRS89</td>
+                            <td id="m-infocoordinates-datum" colspan="2">{{datum}}</td>
                         </tr>
+                        <tbody id="m-infocoordinates-geo-coords" class="noDisplay">
+                            <tr tabindex="0">
+                                <td>{{translations.latitude}}</td>
+                                <td id="m-infocoordinates-latitude" colspan="2">--</td>
+                                <td><button type="button" tabindex="0" class="icon-copy noDisplay" id="m-infocoordinates-copylatlon" title="{{translations.copyLatLon}}"></button></td>
+                            <tr tabindex="0">
+                                <td>{{translations.longitude}}</td>
+                                <td id="m-infocoordinates-longitude" colspan="2">--</td>
+                            </tr>
+                        </tbody>
+                        <tbody id="m-infocoordinates-utm-coords" class="noDisplay">
+                            <tr tabindex="0">
+                                <td>{{translations.coordX}}</td>
+                                <td id="m-infocoordinates-coordX" colspan="2">--</td>
+                                <td><button type="button" tabindex="0" class="icon-copy noDisplay" id="m-infocoordinates-copyxy" title="{{translations.copyxy}}"></button></td>
+                            </tr>
+                            <tr tabindex="0">
+                                <td>{{translations.coordY}}</td>
+                                <td id="m-infocoordinates-coordY" colspan="2">--</td>
+                            </tr>
+                        </tbody>
                         <tr tabindex="0">
-                            <td>{{translations.latitude}}</td>
-                            <td id="m-infocoordinates-latitude" colspan="2">--</td>
-                            <td><button type="button" tabindex="0" class="icon-copy noDisplay" id="m-infocoordinates-copylatlon" title="{{translations.copyLatLon}}"></button></td>
-                        <tr tabindex="0">
-                            <td>{{translations.longitude}}</td>
-                            <td id="m-infocoordinates-longitude" colspan="2">--</td>
+                            <td>{{translations.altitude}}</td>
+                            <td id="m-infocoordinates-altitude" colspan="2">--</td>
                         </tr>
                         <tr tabindex="0">
                             <td></td>
@@ -69,19 +86,6 @@
                                     </ul>
                                 </div>
                             </td>
-                        </tr>
-                        <tr tabindex="0">
-                            <td>{{translations.coordX}}</td>
-                            <td id="m-infocoordinates-coordX" colspan="2">--</td>
-                            <td><button type="button" tabindex="0" class="icon-copy noDisplay" id="m-infocoordinates-copyxy" title="{{translations.copyxy}}"></button></td>
-                        </tr>
-                        <tr tabindex="0">
-                            <td>{{translations.coordY}}</td>
-                            <td id="m-infocoordinates-coordY" colspan="2">--</td>
-                        </tr>
-                        <tr tabindex="0">
-                            <td>{{translations.altitude}}</td>
-                            <td id="m-infocoordinates-altitude" colspan="2">--</td>
                         </tr>
                     </tbody>
                 </table>

--- a/api-idee-js/src/plugins/mousesrs/src/impl/ol/js/mousesrscontrol.js
+++ b/api-idee-js/src/plugins/mousesrs/src/impl/ol/js/mousesrscontrol.js
@@ -256,8 +256,8 @@ export default class MouseSRSControl extends IDEE.impl.Control {
 
   changeSRS(map, html) {
     const select = document.querySelector('#m-mousesrs-epsg-selected');
-    this.srs_ = select.value;
-    this.label_ = select.value;
+    this.srs_ = select.value.startsWith('EPSG:') ? select.value : `EPSG:${select.value}`;
+    this.label_ = select.value.startsWith('EPSG:') ? select.value : `EPSG:${select.value}`;
     this.facadeMap_.getMapImpl().removeControl(this.mousePositionControl);
     document.querySelector('div.m-api-idee-container div.m-dialog').remove();
     this.renderPlugin(map, html);
@@ -282,7 +282,7 @@ export default class MouseSRSControl extends IDEE.impl.Control {
         srsUnits = newProj.units_;
       } catch (err) {
         this.srs_ = 'EPSG:4326';
-        this.label_ = 'EPSG:4326';
+        this.label_ = this.formatEPSG(this.srs_);
         IDEE.dialog.error(`${getValue('exception.srs')} ${this.srs_}`);
         // eslint-disable-next-line no-underscore-dangle
         srsUnits = ol.proj.get('EPSG:4326').units_;

--- a/api-idee-js/src/plugins/printviewmanagement/src/facade/js/templateCustomizer.js
+++ b/api-idee-js/src/plugins/printviewmanagement/src/facade/js/templateCustomizer.js
@@ -379,26 +379,18 @@ export default class TemplateCustomizer extends IDEE.Control {
    */
   setupViewScaleListener() {
     const view = this.previewMap.getMapImpl().getView();
-    const unidades = view.getProjection().getUnits();
-    const unidadesMapa = this.getImpl().getMetersPerUnit(unidades);
-    const initialResolution = view.getResolution();
-    const dpi = Number.parseInt(document.querySelector(ID_TEMPLATE_DPI).value, 10);
-    const initalScale = this.getScaleForResolution(initialResolution, unidadesMapa, dpi);
+    const resolution = view.getResolution();
+    const scale = IDEE.impl.utils.getScaleForResolution(
+      resolution,
+      view,
+      IDEE.config.DPI_OGC,
+      true,
+    );
     const scaleEl = document.querySelector(ID_TEMPLATE_SCALE);
     if (scaleEl) {
-      scaleEl.value = `1:${initalScale}`;
-      this.scale = initalScale;
+      scaleEl.value = `1:${scale}`;
+      this.scale = scale;
     }
-
-    view.on('change:resolution', () => {
-      const resolution = view.getResolution();
-      const scale = this.getScaleForResolution(resolution, unidadesMapa, dpi);
-      const scaleElement = document.querySelector(ID_TEMPLATE_SCALE);
-      if (scaleElement) {
-        scaleElement.value = `1:${scale}`;
-        this.scale = scale;
-      }
-    });
   }
 
   /**
@@ -407,8 +399,11 @@ export default class TemplateCustomizer extends IDEE.Control {
   setupMapChangeListener() {
     const view = this.previewMap.getMapImpl().getView();
     view.on('change:center', () => this.updateDataTemplate());
-    view.on('change:resolution', () => this.updateDataTemplate());
     view.on('change:rotation', () => this.updateDataTemplate());
+    this.previewMap.getMapImpl().on('postrender', () => {
+      this.updateDataTemplate();
+      this.setupViewScaleListener();
+    });
   }
 
   /**
@@ -813,7 +808,6 @@ export default class TemplateCustomizer extends IDEE.Control {
 
         this.previewMap.getMapImpl().setView(newView);
         this.previewMap.getMapImpl().renderSync();
-        this.setupViewScaleListener();
 
         const scaleElement = document.querySelector(ID_TEMPLATE_SCALE);
         if (scaleElement) {
@@ -887,7 +881,7 @@ export default class TemplateCustomizer extends IDEE.Control {
       if (isEditable && event.key === 'Enter') {
         isEditable = false;
         inputElement.setAttribute('readonly', 'readonly');
-        this.changeProjection(inputElement.value);
+        this.changeProjection(inputElement.value.startsWith('EPSG:') ? inputElement.value : `EPSG:${inputElement.value}`);
         this.updateDataTemplate();
       }
     });
@@ -924,12 +918,12 @@ export default class TemplateCustomizer extends IDEE.Control {
           );
         } catch (err) {
           this.projection = previousProjection;
-          inputElement.value = this.projection;
           IDEE.dialog.error(`${getValue('exception.srs')} ${this.projection}`);
           return;
         }
       }
 
+      inputElement.value = this.projection;
       this.projectionsOptions_ = IDEE.impl.ol.js.projections.getSupportedProjs();
       selectorEl.innerHTML = `
         <li><a class="m-customize-template-option-disabled" href="#" value="default" tabindex="-1" disabled>
@@ -953,8 +947,8 @@ export default class TemplateCustomizer extends IDEE.Control {
       });
 
       this.previewMap.getMapImpl().setView(newView);
+      this.reproyectLayers(previewView);
       this.previewMap.getMapImpl().renderSync();
-      this.setupViewScaleListener();
 
       const scaleElement = document.querySelector(ID_TEMPLATE_SCALE);
       if (scaleElement) {
@@ -963,6 +957,31 @@ export default class TemplateCustomizer extends IDEE.Control {
         this.scale = scale;
       }
     }
+  }
+
+  /**
+   * Reproyecta las capas del mapa de previsualización para que se ajusten a la nueva proyección
+   * @param {Object} previewView - Vista actual del mapa de previsualización
+   * antes del cambio de proyección
+   */
+  reproyectLayers(previewView) {
+    this.previewMap.getLayers().forEach((layer) => {
+      const impl = layer.getImpl();
+      if (typeof impl.recreateLayer === 'function') {
+        impl.recreateLayer();
+      } else if (typeof impl.refresh === 'function') {
+        impl.refresh(true);
+      } else if (impl.constructor?.name === 'MapLibre') {
+        impl.destroy();
+        impl.addTo(this.previewMap.getImpl(), true);
+        /* eslint-disable-next-line no-underscore-dangle */
+      } else if (typeof impl.setProjection_ === 'function') {
+        const oldProj = { code: previewView.getProjection().getCode() };
+        const newProjObj = { code: this.projection };
+        /* eslint-disable-next-line no-underscore-dangle */
+        impl.setProjection_(oldProj, newProjObj);
+      }
+    });
   }
 
   /**

--- a/api-idee-js/src/plugins/printviewmanagement/src/templates/templateCustomizer.html
+++ b/api-idee-js/src/plugins/printviewmanagement/src/templates/templateCustomizer.html
@@ -53,7 +53,6 @@
       <fieldset>
         <legend>{{translations.epsg}}</legend>
         <div class="m-customize-template-option m-customize-template-select-editable">
-          <!-- Deshabilitado hasta que se arregle la reproyección de capas -->
           <input
             type="text"
             id="epsg-selected"
@@ -65,7 +64,6 @@
             tabindex="{{order}}"
             autocomplete="off"
             readonly="readonly"
-            disabled
           />
           <ul title="{{translations.select_srs}}" id="m-customize-template-srs-selector" class="m-customize-template-srs-selector">
             <li><a href="#" value="default" tabindex="-1" disabled>{{translations.choose_create_epsg}}</a></li>


### PR DESCRIPTION
- Resuelve error al registrar una nueva proyección, como por ejemplo EPSG:25832, en los plugins **mousesrs**, **infocoordinates** y **printviewmanagement**.
- Permite registrar una nueva proyección añadiendo solamente el código de este.
- En el plugin **infocoordinates**, solamente se muestran aquellas coordenadas que concuerden con el tipo de proyección usado en ese momento (proyectado o geográfico). Este cambio se aplica también a la funcionalidad de copiar 'todos los puntos' y 'exportar todos los puntos'.
- En el plugin **printviewmanagement**, se habilita el cambio de proyección en el diseñador de plantilla (previamente deshabilitado hasta el arreglo de la reproyección de capas).