### PR TITLE
Sustituir servicios caídos en los test PLAY-09 y PLAY-19

### DIFF
--- a/api-idee-js/test/playwright/ol/PLAY-09-wms.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-09-wms.spec.js
@@ -203,9 +203,9 @@ test.describe('IDEE.layer.WMS', () => {
         window.wms_001 = wms_001;
 
         const wms_002 = new IDEE.layer.WMS({
-          url: 'https://www.ideandalucia.es/wms/mta10v_2007?',
-          name: 'Limites',
-          legend: 'Límites',
+          url: 'https://servicios.idee.es/wms-inspire/hidrografia?',
+          name: 'HY.Network',
+          legend: 'Red hidrográfica',
           isBase: true,
         });
         window.wms_002 = wms_002;

--- a/api-idee-js/test/playwright/ol/PLAY-19-wfs.spec.js
+++ b/api-idee-js/test/playwright/ol/PLAY-19-wfs.spec.js
@@ -12,10 +12,10 @@ test.describe('IDEE.layer.WFS', () => {
   test('Method setName', async ({ page }) => {
     await page.evaluate(() => {
       const wfs_001 = new IDEE.layer.WFS({
-        url: 'https://www.ideandalucia.es/services/DERA_g11_patrimonio/wfs?',
-        namespace: 'DERA_g11_patrimonio',
-        name: 'g11_05_Cavidad',
-        legend: 'Cavidades',
+        url: 'https://hcsigc.juntadeandalucia.es/geoserver/wfs?',
+        namespace: 'IECA',
+        name: 'sigc_provincias_pob_centroides_1724756847583',
+        legend: 'Provincias',
         geometry: 'POINT',
       });
       window.wfs_001 = wfs_001;
@@ -29,18 +29,18 @@ test.describe('IDEE.layer.WFS', () => {
         });
       });
     });
-    await page.evaluate(() => window.wfs_001.setName('g11_05_Cavidad'));
+    await page.evaluate(() => window.wfs_001.setName('sigc_provincias_pob_centroides_1724756847583'));
     const nameWFS = await page.evaluate(() => window.wfs_001.name);
-    expect(nameWFS).toEqual('g11_05_Cavidad');
+    expect(nameWFS).toEqual('sigc_provincias_pob_centroides_1724756847583');
   });
 
   test('Methods setName, setNamespace and setURL', async ({ page }) => {
     await page.evaluate(() => {
       const wfs_002 = new IDEE.layer.WFS({
-        url: 'https://www.ideandalucia.es/services/DERA_g11_patrimonio/wfs?',
-        namespace: 'DERA_g11_patrimonio',
-        name: 'g11_05_Cavidad',
-        legend: 'Cavidades',
+        url: 'https://hcsigc.juntadeandalucia.es/geoserver/wfs?',
+        namespace: 'IECA',
+        name: 'sigc_provincias_pob_centroides_1724756847583',
+        legend: 'Provincias',
         geometry: 'POINT',
       });
       window.wfs_002 = wfs_002;
@@ -54,15 +54,15 @@ test.describe('IDEE.layer.WFS', () => {
         });
       });
     });
-    await page.evaluate(() => window.wfs_002.setName('g11_05_Cavidad'));
+    await page.evaluate(() => window.wfs_002.setName('sigc_provincias_pob_centroides_1724756847583'));
     const nameWFS = await page.evaluate(() => window.wfs_002.name);
-    expect(nameWFS).toEqual('g11_05_Cavidad');
-    await page.evaluate(() => window.wfs_002.setNamespace('DERA_g11_patrimonio'));
+    expect(nameWFS).toEqual('sigc_provincias_pob_centroides_1724756847583');
+    await page.evaluate(() => window.wfs_002.setNamespace('IECA'));
     const namespaceWFS = await page.evaluate(() => window.wfs_002.namespace);
-    expect(namespaceWFS).toEqual('DERA_g11_patrimonio');
-    await page.evaluate(() => window.wfs_002.setURL('https://www.ideandalucia.es/services/DERA_g11_patrimonio/wfs?'));
+    expect(namespaceWFS).toEqual('IECA');
+    await page.evaluate(() => window.wfs_002.setURL('https://hcsigc.juntadeandalucia.es/geoserver/wfs?'));
     const urlWFS = await page.evaluate(() => window.wfs_002.url);
-    expect(urlWFS).toEqual('https://www.ideandalucia.es/services/DERA_g11_patrimonio/wfs?');
+    expect(urlWFS).toEqual('https://hcsigc.juntadeandalucia.es/geoserver/wfs?');
     await expect(page).toHaveScreenshot('snapshot.png', { maxDiffPixelRatio: 0.5 });
   });
 });

--- a/api-idee-rest/src/main/resources/properties/version.properties
+++ b/api-idee-rest/src/main/resources/properties/version.properties
@@ -1,4 +1,4 @@
 date=${project.release.date}
 number=${pom.version}
-number-ol=10.4.0
+number-ol=10.7.0
 number-cesium=1.118.0


### PR DESCRIPTION
Sustituye en los test indicados los siguientes servicios que actualmente no están disponibles.

- https://www.ideandalucia.es/services/DERA_g11_patrimonio/wfs? por https://hcsigc.juntadeandalucia.es/geoserver/wfs?
- https://www.ideandalucia.es/wms/mta10v_2007? por https://servicios.idee.es/wms-inspire/hidrografia?

Por último se indica la versión actual de OL en el fichero _properties_