### PR TITLE
getFeaturesExtent en capa vectorial

### DIFF
--- a/api-idee-js/src/impl/ol/js/util/Utils.js
+++ b/api-idee-js/src/impl/ol/js/util/Utils.js
@@ -413,8 +413,8 @@ class Utils {
       if (geometry.getType() === 'Point') {
         const units = getUnitsPerMeter(projectionCode, 1000);
         const auxCoord = geometry.getCoordinates();
-        const coordX = auxCoord[0];
-        const coordY = auxCoord[1];
+        const coordX = parseFloat(auxCoord[0]);
+        const coordY = parseFloat(auxCoord[1]);
         extents = [
           [
             coordX - units,


### PR DESCRIPTION
se soluciona problema al obtener la extension de una capa vector con un solo punto mediante el metodo getFeaturesExtent