### PR TITLE
Bug 745 error al arrastrar elementos por el mapa

### DIFF
--- a/api-idee-js/src/facade/js/util/LoadFiles.js
+++ b/api-idee-js/src/facade/js/util/LoadFiles.js
@@ -176,9 +176,10 @@ export const addFileToMap = (map, file) => {
         Dialog.error(getValue('exception').file_extension);
       }
     }
-  } else {
-    Dialog.error(getValue('exception').file_empty);
   }
+  // else {
+  //   Dialog.error(getValue('exception').file_empty);
+  // }
 };
 
 export default {};


### PR DESCRIPTION
Este error es simplemente un dialog implementado que se ha comentado, en el caso de no encontrar un fichero al usar la función, no se hace nada.
Desventaja: Cuando se use para su finalidad, en su zona de descargas tampoco indicará nada.