### PR TITLE
Consume las plantillas de impresión desde las nuevas URLs de estáticos

### DIFF
--- a/api-idee-js/src/plugins/printviewmanagement/README.md
+++ b/api-idee-js/src/plugins/printviewmanagement/README.md
@@ -136,9 +136,9 @@ El constructor se inicializa con un JSON con los siguientes atributos:
   - **filterTemplates**: Listado de rutas realtivas o absolutas de las cuales se obtendrán cada una de las plantillas a elegir en el modo de impresión. Por defecto:
   ```JavaScript
   "filterTemplates": [
-    "https://componentes.idee.es/estaticos/plantillas/html/templateConBorde.html",
-    "https://componentes.idee.es/estaticos/plantillas/html/templateConCabezeraYBorde.html",
-    "https://componentes.idee.es/estaticos/plantillas/html/templateConFooterYBorde.html",
+    "https://componentes.idee.es/estaticos/plantillas/html/mapaConMarco.html",
+    "https://componentes.idee.es/estaticos/plantillas/html/mapaConCabeceraYMarco.html",
+    "https://componentes.idee.es/estaticos/plantillas/html/mapaConPieYMarco.html",
     ],
   ```
   - **defaultOpenControl**: Indica el control que aparecerá abierto al inicio. Por defecto: 0.
@@ -444,9 +444,9 @@ const mp = new IDEE.plugin.PrintViewManagement({
   },
   printermap: {
     filterTemplates: [
-      "https://componentes.idee.es/estaticos/plantillas/html/templateConBorde.html",
-      "https://componentes.idee.es/estaticos/plantillas/html/templateConCabezeraYBorde.html",
-      "https://componentes.idee.es/estaticos/plantillas/html/templateConFooterYBorde.html",
+      "https://componentes.idee.es/estaticos/plantillas/html/mapaConMarco.html",
+      "https://componentes.idee.es/estaticos/plantillas/html/mapaConCabeceraYMarco.html",
+      "https://componentes.idee.es/estaticos/plantillas/html/mapaConPieYMarco.html",
     ],
     showDefaultTemplate: true,
     defaultDpiOptions: [72, 150, 300],

--- a/api-idee-js/src/plugins/printviewmanagement/src/facade/js/i18n/en.json
+++ b/api-idee-js/src/plugins/printviewmanagement/src/facade/js/i18n/en.json
@@ -74,7 +74,7 @@
   "invalidTemplateName": "A template with the same name already exists.",
   "invalidTemplateContent": "A template with the same content already exists.",
   "selectUploadedTemplate": "Select uploaded template",
-  "defaultTemplate": "Default template",
+  "defaultTemplate": "Full map",
   "invalidFileType": "Please select a valid HTML or TXT file",
   "customizeTemplate": "customize and print screen",
   "mapElements": "Map elements",

--- a/api-idee-js/src/plugins/printviewmanagement/src/facade/js/i18n/es.json
+++ b/api-idee-js/src/plugins/printviewmanagement/src/facade/js/i18n/es.json
@@ -74,7 +74,7 @@
   "invalidTemplateName": "Ya existe una plantilla con el mismo nombre.",
   "invalidTemplateContent": "Ya existe una plantilla con el mismo contenido.",
   "selectUploadedTemplate": "Seleccionar plantilla cargada",
-  "defaultTemplate": "Plantilla por defecto",
+  "defaultTemplate": "Mapa completo",
   "invalidFileType": "Por favor, seleccione un archivo HTML o TXT válido",
   "customizeTemplate": "Personalizar e imprimir pantalla",
   "mapElements": "Elementos del mapa",

--- a/api-idee-js/src/plugins/printviewmanagement/src/facade/js/printviewmanagement.js
+++ b/api-idee-js/src/plugins/printviewmanagement/src/facade/js/printviewmanagement.js
@@ -145,9 +145,9 @@ export default class PrintViewManagement extends IDEE.Plugin {
     if (printermap === true) {
       this.printermap = {
         filterTemplates: [
-          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConBorde.html`,
-          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConCabezeraYBorde.html`,
-          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConFooterYBorde.html`,
+          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConMarco.html`,
+          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConCabeceraYMarco.html`,
+          `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConPieYMarco.html`,
         ],
         showDefaultTemplate: true,
         defaultDpiOptions: [72, 150, 300],

--- a/api-idee-js/src/plugins/printviewmanagement/test/test.js
+++ b/api-idee-js/src/plugins/printviewmanagement/test/test.js
@@ -195,9 +195,9 @@ const mp = new PrintViewManagement({
   printermap: {
     tooltip: 'TEST TOOLTIP printermap', // Tooltip del botón para escoger esta opción
     filterTemplates: [
-      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConBorde.html`,
-      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConCabezeraYBorde.html`,
-      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/templateConFooterYBorde.html`,
+      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConMarco.html`,
+      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConCabeceraYMarco.html`,
+      `${IDEE.config.STATIC_RESOURCES_URL}/plantillas/html/mapaConPieYMarco.html`,
     ], // Array de paths que hacen referencia a las plantillas a elegir por el usuario
     showDefaultTemplate: true, // Si se quiere mostrar la opción de elegir la plantilla por defecto que tiene el plugin
     defaultDpiOptions: [72, 150, 300], // Valores DPI a elegir en el modo de impresión printermap

--- a/api-idee-rest/src/main/webapp/printviewmanagement.jsp
+++ b/api-idee-rest/src/main/webapp/printviewmanagement.jsp
@@ -109,7 +109,7 @@
 
         const DEFAULT_georefImageEpsg = '{"tooltip": "Georeferenciar imagen","layers": [{"url": "http://www.ign.es/wms-inspire/mapa-raster?","name": "mtn_rasterizado","format": "image/jpeg","legend": "Mapa ETRS89 UTM"},{"url": "http://www.ign.es/wms-inspire/pnoa-ma?","name": "OI.OrthoimageCoverage","format": "image/jpeg","legend": "Imagen (PNOA) ETRS89 UTM"}], "defaultDpiOptions": [72, 150, 300]}';
         const DEFAULT_georefImage = '{"tooltip": "Georeferenciar imagen","printSelector": true, "defaultDpiOptions": [72, 150, 300]}';
-        const DEFAULT_printermap = '{"filterTemplates": ["${api-idee.static_resources.url}/plantillas/html/templateConBorde.html", "${api-idee.static_resources.url}/plantillas/html/templateConCabezeraYBorde.html", "${api-idee.static_resources.url}/plantillas/html/templateConFooterYBorde.html"],"showDefaultTemplate": false, "defaultDpiOptions": [72, 150, 300], "layoutsRestraintFromDpi": ["screensize", "A0", "A1", "A2"]}';
+        const DEFAULT_printermap = '{"filterTemplates": ["${api-idee.static_resources.url}/plantillas/html/mapaConMarco.html", "${api-idee.static_resources.url}/plantillas/html/mapaConPieYMarco.html", "${api-idee.static_resources.url}/plantillas/html/mapaConCabeceraYMarco.html"],"showDefaultTemplate": false, "defaultDpiOptions": [72, 150, 300], "layoutsRestraintFromDpi": ["screensize", "A0", "A1", "A2"]}';
 
         const map = IDEE.map({
             container: 'mapjs',


### PR DESCRIPTION
Se cambia las URLs de las plantillas disponibles de printviewmanagement para que se consuman correctamente en la versión 1.1 del plugin